### PR TITLE
fix: run runtime sample from disposable fixture copy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ validate:
 	$(PYTHON) scripts/run_adherence_evals.py
 
 runtime-sample:
-	$(PYTHON) scripts/run_orchestrator.py run --task-dir examples/runtime-fixtures/small-doc-task --route small
+	$(PYTHON) scripts/run_runtime_sample.py --fixture-dir examples/runtime-fixtures/small-doc-task --route small
 
 adherence-evals:
 	$(PYTHON) scripts/run_adherence_evals.py

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ make runtime-sample
 
 ## Runtime sample
 ```bash
-python3 scripts/run_orchestrator.py run --task-dir examples/runtime-fixtures/small-doc-task --route small
+python3 scripts/run_runtime_sample.py --fixture-dir examples/runtime-fixtures/small-doc-task --route small
 python3 scripts/run_orchestrator.py execute --task-dir examples/runtime-fixtures/small-doc-task --route small --adapter codex
 python3 scripts/run_orchestrator.py advance --task-dir examples/runtime-fixtures/small-doc-task --route small --current-stage clarify
 python3 scripts/run_orchestrator.py advance --task-dir examples/runtime-fixtures/small-doc-task --route small --current-stage clarify --execute --adapter cursor
@@ -67,6 +67,8 @@ python3 scripts/run_orchestrator.py retry --task-dir examples/runtime-fixtures/s
 python3 scripts/run_orchestrator.py step-back --task-dir examples/runtime-fixtures/small-doc-task --route small --current-stage quality-review
 python3 scripts/run_orchestrator.py escalate --task-dir examples/runtime-fixtures/small-doc-task --from-route small
 ```
+
+`run_runtime_sample.py`는 fixture를 임시 workspace로 복사한 뒤 실행해서 샘플 명령만으로 tracked runtime fixture가 dirty 상태가 되지 않게 막는다. manual `execute`/`advance`/`retry` 예시는 여전히 원본 task-dir를 직접 대상으로 삼지만, `run` 샘플은 disposable copy에서만 돈다.
 
 이 CLI는 local artifact 디렉터리를 기준으로 route 실행과 recovery helper를 노출한다. `run`은 artifact/gate 기준으로 route 상태를 진행하는 orchestration 명령이고, `execute`는 현재 stage를 어댑터로 실행한다. `advance --execute`는 다음 stage로 넘긴 뒤 바로 실행까지 붙이되, 실행이 실패하면 stage pointer를 커밋하지 않는다. medium/large route에서는 `advance`/`run` 모두 `plan-ledger.json`이 있어야 하고, `step-back`은 되감는 stage에 해당하는 review approval/evidence만 지운다. 정책 위반이나 잘못된 route가 들어오면 traceback 대신 `ERROR:` 형식의 명시적 runtime 오류를 반환한다.
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ python3 scripts/run_orchestrator.py step-back --task-dir examples/runtime-fixtur
 python3 scripts/run_orchestrator.py escalate --task-dir examples/runtime-fixtures/small-doc-task --from-route small
 ```
 
-`run_runtime_sample.py`는 fixture를 임시 workspace로 복사한 뒤 실행해서 샘플 명령만으로 tracked runtime fixture가 dirty 상태가 되지 않게 막는다. manual `execute`/`advance`/`retry` 예시는 여전히 원본 task-dir를 직접 대상으로 삼지만, `run` 샘플은 disposable copy에서만 돈다.
+`run_runtime_sample.py`는 fixture를 임시 workspace로 복사한 뒤 실행해서 샘플 명령만으로 tracked runtime fixture가 dirty 상태가 되지 않게 막는다. 실행 결과에는 원본 fixture 경로만 다시 싣고, 임시 workspace 경로는 노출하지 않는다. manual `execute`/`advance`/`retry` 예시는 여전히 원본 task-dir를 직접 대상으로 삼지만, `run` 샘플은 disposable copy에서만 돈다.
 
 이 CLI는 local artifact 디렉터리를 기준으로 route 실행과 recovery helper를 노출한다. `run`은 artifact/gate 기준으로 route 상태를 진행하는 orchestration 명령이고, `execute`는 현재 stage를 어댑터로 실행한다. `advance --execute`는 다음 stage로 넘긴 뒤 바로 실행까지 붙이되, 실행이 실패하면 stage pointer를 커밋하지 않는다. medium/large route에서는 `advance`/`run` 모두 `plan-ledger.json`이 있어야 하고, `step-back`은 되감는 stage에 해당하는 review approval/evidence만 지운다. 정책 위반이나 잘못된 route가 들어오면 traceback 대신 `ERROR:` 형식의 명시적 runtime 오류를 반환한다.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,6 +9,7 @@ P0에서 필요한 최소 자동화를 둔다.
 - `generate_adapters.py` : canonical policy와 prompt를 target별 generated output으로 변환
 - `validate_generated.py` : generated 산출물이 최소 규칙을 지키는지 검증
 - `validate_sample_artifacts.py` : sample artifact fixture가 schema와 맞는지 검증
+- `run_runtime_sample.py` : runtime sample을 disposable fixture copy에서 실행해서 tracked example이 더러워지지 않게 보호
 
 ## 권장 실행 순서
 1. `python3 scripts/validate_structure.py`
@@ -16,3 +17,7 @@ P0에서 필요한 최소 자동화를 둔다.
 3. `python3 scripts/generate_adapters.py`
 4. `python3 scripts/validate_generated.py`
 5. `python3 scripts/validate_sample_artifacts.py`
+
+## Runtime sample
+- `python3 scripts/run_runtime_sample.py --fixture-dir examples/runtime-fixtures/small-doc-task --route small`
+- disposable copy에서 실행하므로 tracked fixture가 dirty 상태로 남지 않는다.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,3 +22,4 @@ P0에서 필요한 최소 자동화를 둔다.
 - `python3 scripts/run_runtime_sample.py --fixture-dir examples/runtime-fixtures/small-doc-task --route small`
 - `--fixture-dir`는 task fixture 디렉터리를 가리켜야 하며, 파일 경로면 명시적 `ERROR:`로 실패한다.
 - disposable copy에서 실행하므로 tracked fixture가 dirty 상태로 남지 않는다.
+- 임시 workspace는 실행 종료와 함께 지워지므로, 출력에는 disposable workspace 경로를 싣지 않는다.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,4 +20,5 @@ P0에서 필요한 최소 자동화를 둔다.
 
 ## Runtime sample
 - `python3 scripts/run_runtime_sample.py --fixture-dir examples/runtime-fixtures/small-doc-task --route small`
+- `--fixture-dir`는 task fixture 디렉터리를 가리켜야 하며, 파일 경로면 명시적 `ERROR:`로 실패한다.
 - disposable copy에서 실행하므로 tracked fixture가 dirty 상태로 남지 않는다.

--- a/scripts/run_runtime_sample.py
+++ b/scripts/run_runtime_sample.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_FIXTURE = ROOT / "examples" / "runtime-fixtures" / "small-doc-task"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run the ForgeFlow runtime sample against a disposable copy of a fixture task directory."
+    )
+    parser.add_argument(
+        "--fixture-dir",
+        default=str(DEFAULT_FIXTURE),
+        help="fixture task directory to copy before running the sample",
+    )
+    parser.add_argument("--route", default="small", help="route name to execute")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    fixture_dir = Path(args.fixture_dir).resolve()
+    if not fixture_dir.exists():
+        print(f"ERROR: fixture directory not found: {fixture_dir}", file=sys.stderr)
+        return 1
+
+    with tempfile.TemporaryDirectory(prefix="forgeflow-runtime-sample-") as td:
+        workspace = Path(td)
+        task_dir = workspace / fixture_dir.name
+        shutil.copytree(fixture_dir, task_dir)
+
+        command = [
+            sys.executable,
+            str(ROOT / "scripts" / "run_orchestrator.py"),
+            "run",
+            "--task-dir",
+            str(task_dir),
+            "--route",
+            args.route,
+        ]
+        result = subprocess.run(command, cwd=ROOT, capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            if result.stdout:
+                print(result.stdout, end="")
+            if result.stderr:
+                print(result.stderr, file=sys.stderr, end="")
+            return result.returncode
+
+        payload = json.loads(result.stdout)
+        payload["sample_source_fixture"] = str(fixture_dir.relative_to(ROOT)) if fixture_dir.is_relative_to(ROOT) else str(fixture_dir)
+        payload["sample_workspace"] = str(task_dir)
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_runtime_sample.py
+++ b/scripts/run_runtime_sample.py
@@ -20,7 +20,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--fixture-dir",
         default=str(DEFAULT_FIXTURE),
-        help="fixture task directory to copy before running the sample",
+        help="fixture task directory to copy before running the sample (must be a directory)",
     )
     parser.add_argument("--route", default="small", help="route name to execute")
     return parser
@@ -31,6 +31,9 @@ def main() -> int:
     fixture_dir = Path(args.fixture_dir).resolve()
     if not fixture_dir.exists():
         print(f"ERROR: fixture directory not found: {fixture_dir}", file=sys.stderr)
+        return 1
+    if not fixture_dir.is_dir():
+        print(f"ERROR: fixture directory is not a directory: {fixture_dir}", file=sys.stderr)
         return 1
 
     with tempfile.TemporaryDirectory(prefix="forgeflow-runtime-sample-") as td:

--- a/scripts/run_runtime_sample.py
+++ b/scripts/run_runtime_sample.py
@@ -60,7 +60,6 @@ def main() -> int:
 
         payload = json.loads(result.stdout)
         payload["sample_source_fixture"] = str(fixture_dir.relative_to(ROOT)) if fixture_dir.is_relative_to(ROOT) else str(fixture_dir)
-        payload["sample_workspace"] = str(task_dir)
         print(json.dumps(payload, indent=2, ensure_ascii=False))
     return 0
 

--- a/tests/test_runtime_orchestrator.py
+++ b/tests/test_runtime_orchestrator.py
@@ -1984,10 +1984,44 @@ def test_cli_medium_route_execute_flow_is_automated_end_to_end(tmp_path: Path) -
 def test_readme_examples_describe_manual_execution_flow() -> None:
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
 
+    assert "scripts/run_runtime_sample.py --fixture-dir" in readme
     assert "scripts/run_orchestrator.py execute --task-dir" in readme
     assert "advance --execute" in readme
     assert "run`은 artifact/gate 기준으로 route 상태를 진행" in readme
     assert "execute`는 현재 stage를 어댑터로 실행" in readme
+
+
+def test_runtime_sample_cli_uses_disposable_fixture_copy() -> None:
+    fixture_dir = ROOT / "examples" / "runtime-fixtures" / "small-doc-task"
+    tracked_files = {
+        rel: (fixture_dir / rel).read_text(encoding="utf-8")
+        for rel in ["checkpoint.json", "decision-log.json", "session-state.json"]
+    }
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/run_runtime_sample.py",
+            "--fixture-dir",
+            str(fixture_dir),
+            "--route",
+            "small",
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "completed"
+    assert payload["current_stage"] == "finalize"
+    assert payload["sample_source_fixture"] == "examples/runtime-fixtures/small-doc-task"
+    assert "forgeflow-runtime-sample-" in payload["sample_workspace"]
+
+    for rel, original in tracked_files.items():
+        assert (fixture_dir / rel).read_text(encoding="utf-8") == original
 
 
 def test_cli_reports_runtime_violations_without_tracebacks(tmp_path: Path) -> None:

--- a/tests/test_runtime_orchestrator.py
+++ b/tests/test_runtime_orchestrator.py
@@ -2019,7 +2019,7 @@ def test_runtime_sample_cli_uses_disposable_fixture_copy() -> None:
     assert payload["status"] == "completed"
     assert payload["current_stage"] == "finalize"
     assert payload["sample_source_fixture"] == "examples/runtime-fixtures/small-doc-task"
-    assert "forgeflow-runtime-sample-" in payload["sample_workspace"]
+    assert "sample_workspace" not in payload
 
     for rel, original in tracked_files.items():
         assert (fixture_dir / rel).read_text(encoding="utf-8") == original

--- a/tests/test_runtime_orchestrator.py
+++ b/tests/test_runtime_orchestrator.py
@@ -1994,8 +1994,9 @@ def test_readme_examples_describe_manual_execution_flow() -> None:
 def test_runtime_sample_cli_uses_disposable_fixture_copy() -> None:
     fixture_dir = ROOT / "examples" / "runtime-fixtures" / "small-doc-task"
     tracked_files = {
-        rel: (fixture_dir / rel).read_text(encoding="utf-8")
-        for rel in ["checkpoint.json", "decision-log.json", "session-state.json"]
+        path.relative_to(fixture_dir): path.read_text(encoding="utf-8")
+        for path in fixture_dir.rglob("*")
+        if path.is_file()
     }
 
     result = subprocess.run(
@@ -2022,6 +2023,30 @@ def test_runtime_sample_cli_uses_disposable_fixture_copy() -> None:
 
     for rel, original in tracked_files.items():
         assert (fixture_dir / rel).read_text(encoding="utf-8") == original
+
+
+def test_runtime_sample_cli_rejects_non_directory_fixture(tmp_path: Path) -> None:
+    file_path = tmp_path / "not-a-dir.json"
+    file_path.write_text("{}", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/run_runtime_sample.py",
+            "--fixture-dir",
+            str(file_path),
+            "--route",
+            "small",
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert result.stderr.startswith("ERROR: fixture directory is not a directory:")
 
 
 def test_cli_reports_runtime_violations_without_tracebacks(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- run the runtime sample against a disposable copy of the small-doc-task fixture
- prevent `make runtime-sample` from dirtying tracked runtime fixture files
- harden `run_runtime_sample.py` so `--fixture-dir` must be a real directory and failures stay explicit
- document the safer sample flow and add regression coverage for fixture cleanliness and invalid fixture paths

## Why
`make runtime-sample` previously executed directly against the tracked sample fixture and left the repo dirty. That is a lame first-run DX for a repo that is supposed to feel disciplined.

The follow-up hardening also removes an ugly traceback path when a user passes a file instead of a fixture directory.

## Test Plan
- [x] `pytest -q tests/test_runtime_orchestrator.py`
- [x] `python3 scripts/run_runtime_sample.py --fixture-dir examples/runtime-fixtures/small-doc-task --route small`
- [x] `python3 scripts/run_runtime_sample.py --fixture-dir /tmp/not-a-dir.json`
- [x] `make validate`
- [x] `pytest -q`
- [x] `make runtime-sample`

## Notes
- manual `execute` / `advance` / `retry` examples still target an explicit task directory on purpose
- only the `run` sample was redirected to a disposable copy
- fixture cleanliness regression coverage now checks the whole tracked fixture tree, not just a few files
- success payload no longer exposes a deleted temporary workspace path; only the source fixture path is reported

