### PR TITLE
feat: harden runtime semantic validation

### DIFF
--- a/examples/artifacts/invalid/review-report-open-blockers-wrong-type.sample.json
+++ b/examples/artifacts/invalid/review-report-open-blockers-wrong-type.sample.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-invalid-review-003",
+  "review_type": "quality",
+  "verdict": "changes_requested",
+  "findings": ["verification gap remains"],
+  "open_blockers": "integration test evidence missing",
+  "safe_for_next_stage": false,
+  "next_action": "execute stage evidence를 보강"
+}

--- a/forgeflow_runtime/orchestrator.py
+++ b/forgeflow_runtime/orchestrator.py
@@ -410,6 +410,74 @@ def _load_session_state(task_dir: Path, *, canonical_task_id: str) -> dict[str, 
     return _load_validated_artifact(task_dir, "session-state", expected_task_id=canonical_task_id)
 
 
+def _validate_review_semantics(payload: dict[str, Any], *, source_name: str) -> None:
+    verdict = payload.get("verdict")
+    review_type = payload.get("review_type")
+    open_blockers = payload.get("open_blockers", [])
+    if open_blockers is None:
+        open_blockers = []
+    if verdict == "approved" and open_blockers:
+        raise RuntimeViolation(f"approved {source_name} cannot declare open_blockers")
+    if review_type == "quality" and verdict == "approved" and payload.get("safe_for_next_stage") is False:
+        raise RuntimeViolation(f"quality {source_name} approved verdict cannot set safe_for_next_stage=false")
+
+
+def _expected_plan_ledger_ref(*, route_name: str, plan_ledger: dict[str, Any] | None) -> str:
+    if route_name == "small" or plan_ledger is None:
+        return "run-state.json"
+    return "plan-ledger.json"
+
+
+def _validate_session_state(
+    task_dir: Path,
+    session_state: dict[str, Any],
+    *,
+    route_name: str,
+    run_state: dict[str, Any],
+    plan_ledger: dict[str, Any] | None,
+) -> None:
+    for field_name in ["plan_ref", "plan_ledger_ref", "run_state_ref", "latest_checkpoint_ref"]:
+        ref = session_state.get(field_name)
+        if not isinstance(ref, str) or not ref:
+            raise RuntimeViolation(f"session-state.json {field_name} is required")
+        resolved = _checkpoint_ref_path(task_dir, ref)
+        if not resolved.exists():
+            raise RuntimeViolation(f"session-state.json {field_name} {ref} does not exist")
+    if session_state.get("latest_checkpoint_ref") != "checkpoint.json":
+        raise RuntimeViolation(
+            f"session-state.json latest_checkpoint_ref {session_state.get('latest_checkpoint_ref')} must point to checkpoint.json"
+        )
+    if session_state.get("run_state_ref") != "run-state.json":
+        raise RuntimeViolation(
+            f"session-state.json run_state_ref {session_state.get('run_state_ref')} must point to run-state.json"
+        )
+    if session_state.get("route") != route_name:
+        raise RuntimeViolation(
+            f"session-state.json route {session_state.get('route')} does not match canonical route {route_name}"
+        )
+    if session_state.get("current_stage") != run_state.get("current_stage"):
+        raise RuntimeViolation(
+            f"session-state.json current_stage {session_state.get('current_stage')} does not match run-state current_stage {run_state.get('current_stage')}"
+        )
+    expected_plan_ledger_ref = _expected_plan_ledger_ref(route_name=route_name, plan_ledger=plan_ledger)
+    if session_state.get("plan_ledger_ref") != expected_plan_ledger_ref:
+        raise RuntimeViolation(
+            f"session-state.json plan_ledger_ref {session_state.get('plan_ledger_ref')} must point to {expected_plan_ledger_ref} for route {route_name}"
+        )
+    latest_review_ref = session_state.get("latest_review_ref")
+    if latest_review_ref is not None:
+        if not isinstance(latest_review_ref, str) or not latest_review_ref:
+            raise RuntimeViolation("session-state.json latest_review_ref must be a non-empty string when present")
+        resolved = _checkpoint_ref_path(task_dir, latest_review_ref)
+        if not resolved.exists():
+            raise RuntimeViolation(f"session-state.json latest_review_ref {latest_review_ref} does not exist")
+        canonical_latest_review_ref = _latest_review_ref(task_dir)
+        if latest_review_ref != canonical_latest_review_ref:
+            raise RuntimeViolation(
+                f"session-state.json latest_review_ref {latest_review_ref} does not match canonical latest review {canonical_latest_review_ref}"
+            )
+
+
 def _checkpoint_ref_path(task_dir: Path, ref: str) -> Path:
     ref_path = Path(ref)
     if ref_path.is_absolute():
@@ -483,6 +551,7 @@ def _latest_review_verdict(task_dir: Path, *, canonical_task_id: str) -> str | N
         return None
     artifact_name = latest_review_ref.removesuffix(".json")
     review = _load_validated_artifact(task_dir, artifact_name, expected_task_id=canonical_task_id)
+    _validate_review_semantics(review, source_name=latest_review_ref)
     verdict = review.get("verdict")
     return verdict if isinstance(verdict, str) and verdict else None
 
@@ -708,6 +777,7 @@ def _sync_review_flags(task_dir: Path, run_state: dict[str, Any], *, canonical_t
         if not review_path.exists():
             continue
         review = _load_validated_artifact(task_dir, artifact_name, expected_task_id=canonical_task_id)
+        _validate_review_semantics(review, source_name=review_path.name)
         if review.get("review_type") == "spec" and review.get("verdict") == "approved":
             run_state["spec_review_approved"] = True
         if review.get("review_type") == "quality" and review.get("verdict") == "approved":
@@ -758,14 +828,23 @@ def _resume_start_index(
     source_name = "plan-ledger" if plan_ledger is not None else "run-state"
     progress_source = _plan_ledger_progress(plan_ledger) if plan_ledger is not None else run_state
     completed_gates = progress_source.get("completed_gates", [])
+    completed_stages = progress_source.get("completed_stages", [])
 
     if current_stage not in route:
         raise RuntimeViolation(f"run-state checkpoint stage {current_stage} is not part of route")
     if not isinstance(completed_gates, list):
         source_name = "plan-ledger" if plan_ledger is not None else "run-state"
         raise RuntimeViolation(f"{source_name} checkpoint completed_gates must be a list")
+    if not isinstance(completed_stages, list):
+        raise RuntimeViolation(f"{source_name} checkpoint completed_stages must be a list")
 
     current_index = route.index(current_stage)
+    allowed_stages = set(route[: current_index + 1])
+    unexpected_stages = [stage_name for stage_name in completed_stages if stage_name not in allowed_stages]
+    if unexpected_stages:
+        raise RuntimeViolation(
+            f"{source_name} checkpoint has out-of-sequence completed stages at {current_stage}: {', '.join(unexpected_stages)}"
+        )
     expected_prefix = _expected_gates_before_stage(route, current_stage, stage_gate_map=stage_gate_map)
     missing_prefix = [gate for gate in expected_prefix if gate not in completed_gates]
     if missing_prefix:
@@ -818,6 +897,7 @@ def _matching_review_payload(
         if not review_path.exists():
             continue
         payload = _load_validated_artifact(task_dir, artifact_name, expected_task_id=canonical_task_id)
+        _validate_review_semantics(payload, source_name=review_path.name)
         if payload.get("review_type") == expected_review_type and payload.get("verdict") == expected_verdict:
             return payload
     return None
@@ -1015,29 +1095,13 @@ def resume_task(task_dir: Path, policy: RuntimePolicy, route_name: str | None = 
         run_state=run_state,
         plan_ledger=plan_ledger,
     )
-    for field_name in ["plan_ref", "plan_ledger_ref", "run_state_ref", "latest_checkpoint_ref"]:
-        ref = session_state.get(field_name)
-        if not isinstance(ref, str) or not ref:
-            raise RuntimeViolation(f"session-state.json {field_name} is required")
-        resolved = _checkpoint_ref_path(task_dir, ref)
-        if not resolved.exists():
-            raise RuntimeViolation(f"session-state.json {field_name} {ref} does not exist")
-    if session_state.get("latest_checkpoint_ref") != "checkpoint.json":
-        raise RuntimeViolation(
-            f"session-state.json latest_checkpoint_ref {session_state.get('latest_checkpoint_ref')} must point to checkpoint.json"
-        )
-    if session_state.get("run_state_ref") != "run-state.json":
-        raise RuntimeViolation(
-            f"session-state.json run_state_ref {session_state.get('run_state_ref')} must point to run-state.json"
-        )
-    if session_state.get("route") != inferred_route:
-        raise RuntimeViolation(
-            f"session-state.json route {session_state.get('route')} does not match canonical route {inferred_route}"
-        )
-    if session_state.get("current_stage") != run_state.get("current_stage"):
-        raise RuntimeViolation(
-            f"session-state.json current_stage {session_state.get('current_stage')} does not match run-state current_stage {run_state.get('current_stage')}"
-        )
+    _validate_session_state(
+        task_dir,
+        session_state,
+        route_name=inferred_route,
+        run_state=run_state,
+        plan_ledger=plan_ledger,
+    )
     return {
         "task_id": canonical_task_id,
         "route": inferred_route,

--- a/schemas/review-report.schema.json
+++ b/schemas/review-report.schema.json
@@ -20,6 +20,12 @@
     },
     "approved_by": {"type": "string", "minLength": 1},
     "next_action": {"type": "string", "minLength": 1},
+    "safe_for_next_stage": {"type": "boolean"},
+    "open_blockers": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1},
+      "uniqueItems": true
+    },
     "evidence_refs": {
       "type": "array",
       "items": {"type": "string", "minLength": 1},

--- a/scripts/validate_sample_artifacts.py
+++ b/scripts/validate_sample_artifacts.py
@@ -24,6 +24,7 @@ NEGATIVE_SAMPLES = {
     "decision-log-invalid-entry.sample.json": ROOT / "schemas/decision-log.schema.json",
     "review-report-approved-missing-approved-by.sample.json": ROOT / "schemas/review-report.schema.json",
     "review-report-blocked-missing-next-action.sample.json": ROOT / "schemas/review-report.schema.json",
+    "review-report-open-blockers-wrong-type.sample.json": ROOT / "schemas/review-report.schema.json",
     "plan-ledger-done-without-evidence.sample.json": ROOT / "schemas/plan-ledger.schema.json",
     "checkpoint-invalid-updated-at.sample.json": ROOT / "schemas/checkpoint.schema.json",
     "session-state-missing-ref.sample.json": ROOT / "schemas/session-state.schema.json",

--- a/tests/test_runtime_orchestrator.py
+++ b/tests/test_runtime_orchestrator.py
@@ -471,6 +471,48 @@ def test_run_route_resumes_from_existing_checkpoint(tmp_path: Path) -> None:
     assert checkpoint["open_blockers"] == []
 
 
+def test_run_route_rejects_approved_review_with_open_blockers(tmp_path: Path) -> None:
+    policy = load_runtime_policy(ROOT)
+    task_dir = _make_task_dir(tmp_path)
+    _write_json(
+        task_dir / "review-report.json",
+        {
+            "schema_version": "0.1",
+            "task_id": "task-001",
+            "review_type": "quality",
+            "verdict": "approved",
+            "findings": ["looks fine"],
+            "approved_by": "quality-reviewer",
+            "open_blockers": ["integration evidence missing"],
+            "next_action": "finalize 가능",
+        },
+    )
+
+    with pytest.raises(RuntimeViolation, match="approved review-report.json cannot declare open_blockers"):
+        run_route(task_dir=task_dir, policy=policy, route_name="small")
+
+
+def test_run_route_rejects_approved_quality_review_marked_unsafe(tmp_path: Path) -> None:
+    policy = load_runtime_policy(ROOT)
+    task_dir = _make_task_dir(tmp_path)
+    _write_json(
+        task_dir / "review-report.json",
+        {
+            "schema_version": "0.1",
+            "task_id": "task-001",
+            "review_type": "quality",
+            "verdict": "approved",
+            "findings": ["looks fine"],
+            "approved_by": "quality-reviewer",
+            "safe_for_next_stage": False,
+            "next_action": "finalize 보류",
+        },
+    )
+
+    with pytest.raises(RuntimeViolation, match="quality review-report.json approved verdict cannot set safe_for_next_stage=false"):
+        run_route(task_dir=task_dir, policy=policy, route_name="small")
+
+
 def test_run_route_rejects_mismatched_checkpoint_route(tmp_path: Path) -> None:
     policy = load_runtime_policy(ROOT)
     task_dir = _make_task_dir(tmp_path)
@@ -506,6 +548,109 @@ def test_run_route_rejects_mismatched_checkpoint_route(tmp_path: Path) -> None:
         run_route(task_dir=task_dir, policy=policy, route_name="small")
 
 
+def test_resume_rejects_medium_session_state_with_wrong_plan_ledger_ref(tmp_path: Path) -> None:
+    policy = load_runtime_policy(ROOT)
+    task_dir = _make_task_dir(tmp_path)
+    _write_medium_plan_artifacts(task_dir, route_name="medium")
+    _write_json(
+        task_dir / "checkpoint.json",
+        {
+            "schema_version": "0.1",
+            "task_id": "task-001",
+            "route": "medium",
+            "current_stage": "clarify",
+            "plan_ref": "plan.json",
+            "plan_ledger_ref": "plan-ledger.json",
+            "run_state_ref": "run-state.json",
+            "next_action": "execute로 진행",
+            "open_blockers": [],
+            "updated_at": "2026-04-22T00:05:00Z"
+        },
+    )
+    _write_json(
+        task_dir / "session-state.json",
+        {
+            "schema_version": "0.1",
+            "task_id": "task-001",
+            "route": "medium",
+            "current_stage": "clarify",
+            "plan_ref": "plan.json",
+            "plan_ledger_ref": "run-state.json",
+            "run_state_ref": "run-state.json",
+            "latest_checkpoint_ref": "checkpoint.json",
+            "next_action": "execute로 진행",
+            "updated_at": "2026-04-22T00:05:00Z"
+        },
+    )
+
+    with pytest.raises(RuntimeViolation, match="session-state.json plan_ledger_ref run-state.json must point to plan-ledger.json for route medium"):
+        resume_task(task_dir=task_dir, policy=policy, route_name="medium")
+
+
+def test_resume_rejects_stale_session_state_latest_review_ref(tmp_path: Path) -> None:
+    policy = load_runtime_policy(ROOT)
+    task_dir = _make_task_dir(tmp_path)
+    _write_json(
+        task_dir / "review-report-spec.json",
+        {
+            "schema_version": "0.1",
+            "task_id": "task-001",
+            "review_type": "spec",
+            "verdict": "approved",
+            "findings": ["spec ok"],
+            "approved_by": "spec-reviewer",
+            "next_action": "quality-review로 진행",
+        },
+    )
+    _write_json(
+        task_dir / "review-report-quality.json",
+        {
+            "schema_version": "0.1",
+            "task_id": "task-001",
+            "review_type": "quality",
+            "verdict": "approved",
+            "findings": ["quality ok"],
+            "approved_by": "quality-reviewer",
+            "next_action": "finalize 가능",
+        },
+    )
+    _write_json(
+        task_dir / "checkpoint.json",
+        {
+            "schema_version": "0.1",
+            "task_id": "task-001",
+            "route": "small",
+            "current_stage": "clarify",
+            "plan_ref": "brief.json",
+            "plan_ledger_ref": "run-state.json",
+            "run_state_ref": "run-state.json",
+            "latest_review_ref": "review-report-quality.json",
+            "next_action": "execute로 진행",
+            "open_blockers": [],
+            "updated_at": "2026-04-22T00:05:00Z"
+        },
+    )
+    _write_json(
+        task_dir / "session-state.json",
+        {
+            "schema_version": "0.1",
+            "task_id": "task-001",
+            "route": "small",
+            "current_stage": "clarify",
+            "plan_ref": "brief.json",
+            "plan_ledger_ref": "run-state.json",
+            "run_state_ref": "run-state.json",
+            "latest_checkpoint_ref": "checkpoint.json",
+            "latest_review_ref": "review-report-spec.json",
+            "next_action": "execute로 진행",
+            "updated_at": "2026-04-22T00:05:00Z"
+        },
+    )
+
+    with pytest.raises(RuntimeViolation, match="session-state.json latest_review_ref review-report-spec.json does not match canonical latest review review-report-quality.json"):
+        resume_task(task_dir=task_dir, policy=policy, route_name="small")
+
+
 def test_run_route_rejects_checkpoint_gate_drift(tmp_path: Path) -> None:
     policy = load_runtime_policy(ROOT)
     task_dir = _make_task_dir(tmp_path)
@@ -539,6 +684,34 @@ def test_run_route_rejects_checkpoint_gate_drift(tmp_path: Path) -> None:
 
     with pytest.raises(RuntimeViolation, match="run-state checkpoint is missing completed gates before execute: clarification_complete"):
         run_route(task_dir=task_dir, policy=policy, route_name="small")
+
+
+def test_run_route_rejects_medium_plan_ledger_out_of_order_completed_stages(tmp_path: Path) -> None:
+    policy = load_runtime_policy(ROOT)
+    task_dir = _make_task_dir(tmp_path)
+    _write_medium_plan_artifacts(task_dir, route_name="medium")
+    run_state = json.loads((task_dir / "run-state.json").read_text(encoding="utf-8"))
+    run_state["current_stage"] = "execute"
+    _write_json(task_dir / "run-state.json", run_state)
+    plan_ledger = json.loads((task_dir / "plan-ledger.json").read_text(encoding="utf-8"))
+    plan_ledger["completed_stages"] = ["clarify", "plan", "quality-review"]
+    plan_ledger["completed_gates"] = ["clarification_complete", "plan_executable"]
+    _write_json(task_dir / "plan-ledger.json", plan_ledger)
+    _write_json(
+        task_dir / "review-report.json",
+        {
+            "schema_version": "0.1",
+            "task_id": "task-001",
+            "review_type": "quality",
+            "verdict": "approved",
+            "findings": ["looks fine"],
+            "approved_by": "quality-reviewer",
+            "next_action": "finalize 가능",
+        },
+    )
+
+    with pytest.raises(RuntimeViolation, match="plan-ledger checkpoint has out-of-sequence completed stages at execute: quality-review"):
+        run_route(task_dir=task_dir, policy=policy, route_name="medium")
 
 
 def test_run_route_rejects_future_gate_checkpoint_drift(tmp_path: Path) -> None:

--- a/tests/test_validate_sample_artifacts.py
+++ b/tests/test_validate_sample_artifacts.py
@@ -119,6 +119,29 @@ def test_review_report_schema_requires_next_action_for_non_approved_verdict() ->
     assert any(err.validator == "required" and "next_action" in err.message for err in errors)
 
 
+def test_review_report_schema_accepts_safe_flag_and_open_blockers() -> None:
+    schema = json.loads((ROOT / "schemas" / "review-report.schema.json").read_text(encoding="utf-8"))
+    validator = Draft202012Validator(schema, format_checker=FormatChecker())
+
+    errors = sorted(
+        validator.iter_errors(
+            {
+                "schema_version": "0.1",
+                "task_id": "task-001",
+                "review_type": "quality",
+                "verdict": "changes_requested",
+                "findings": ["verification gap remains"],
+                "open_blockers": ["integration test evidence missing"],
+                "safe_for_next_stage": False,
+                "next_action": "execute stage evidence를 보강",
+            }
+        ),
+        key=lambda err: list(err.path),
+    )
+
+    assert not errors
+
+
 def test_plan_ledger_schema_requires_evidence_for_done_tasks() -> None:
     schema = json.loads((ROOT / "schemas" / "plan-ledger.schema.json").read_text(encoding="utf-8"))
     validator = Draft202012Validator(schema, format_checker=FormatChecker())
@@ -230,6 +253,7 @@ def test_validate_sample_artifacts_tracks_positive_and_negative_fixtures() -> No
         ("decision-log-invalid-entry.sample.json", "timestamp"),
         ("review-report-approved-missing-approved-by.sample.json", "approved_by"),
         ("review-report-blocked-missing-next-action.sample.json", "next_action"),
+        ("review-report-open-blockers-wrong-type.sample.json", "open_blockers"),
         ("plan-ledger-done-without-evidence.sample.json", "evidence_refs"),
         ("checkpoint-invalid-updated-at.sample.json", "updated_at"),
         ("session-state-missing-ref.sample.json", "plan_ref"),


### PR DESCRIPTION
## Summary
- extend review-report contract with `safe_for_next_stage` and `open_blockers`
- reject approved reviews that still carry blockers or unsafe-next-stage semantics
- tighten session-state and plan-ledger semantic drift checks
- add runtime and sample-artifact tests for the new invariants

## Verification
- [x] `pytest -q tests/test_runtime_orchestrator.py tests/test_validate_sample_artifacts.py`
- [x] `python3 scripts/validate_sample_artifacts.py`
- [x] `python3 scripts/run_adherence_evals.py`
- [x] `make validate`

Closes #17
