### PR TITLE
feat: expand medium and large runtime fixtures

### DIFF
--- a/evals/adherence/README.md
+++ b/evals/adherence/README.md
@@ -13,7 +13,9 @@ make adherence-evals
 - `examples/runtime-fixtures/small-doc-task` small route happy path
 - `examples/runtime-fixtures/resume-small-task` validated checkpoint에서 small route resume
 - `examples/runtime-fixtures/medium-refactor-task` medium route happy path
+- `examples/runtime-fixtures/medium-plan-with-weak-verification` medium route의 richer status/review fixture
 - `examples/runtime-fixtures/large-migration-task` large/high-risk happy path
+- `examples/runtime-fixtures/large-approved-but-unsafe` large route의 caution-heavy review fixture
 - `negative/missing-quality-approval`에서 non-approved quality review 거부
 - `negative/invalid-review-report`에서 schema-invalid review artifact 거부
 - `negative/mixed-task-review-report`에서 다른 task의 review artifact 거부
@@ -23,6 +25,9 @@ make adherence-evals
 - `negative/checkpoint-gate-drift`에서 prefix가 깨진 checkpoint resume 거부
 - `negative/future-gate-checkpoint-drift`에서 미래 gate가 미리 찍힌 checkpoint resume 거부
 - `negative/completed-checkpoint-drift`에서 terminal stage에 있지 않은 completed checkpoint 거부
+- `negative/medium-ledger-gate-drift`에서 medium route plan-ledger의 미래 gate drift 거부
+- `negative/large-spec-quality-mismatch`에서 quality artifact가 spec-review를 대체하지 못함을 검증
+- `negative/large-session-state-stale-review-ref`에서 stale latest_review_ref가 있는 large route resume 거부
 
 핵심 규칙:
 - artifact 없이 stage 전환 금지

--- a/examples/runtime-fixtures/large-approved-but-unsafe/README.md
+++ b/examples/runtime-fixtures/large-approved-but-unsafe/README.md
@@ -1,0 +1,3 @@
+# Large runtime fixture with explicit unsafe handoff note
+
+Large route fixture that remains structurally valid for the current contract, while documenting a review handoff that would become unsafe once stricter next-stage safety semantics are enforced.

--- a/examples/runtime-fixtures/large-approved-but-unsafe/brief.json
+++ b/examples/runtime-fixtures/large-approved-but-unsafe/brief.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-large-unsafe-001",
+  "objective": "Run a large high-risk route fixture",
+  "in_scope": [
+    "runtime",
+    "docs"
+  ],
+  "out_of_scope": [
+    "live deployment"
+  ],
+  "constraints": [
+    "local fixture only"
+  ],
+  "acceptance_criteria": [
+    "large route completes including long-run"
+  ],
+  "risk_level": "high"
+}

--- a/examples/runtime-fixtures/large-approved-but-unsafe/eval-record.json
+++ b/examples/runtime-fixtures/large-approved-but-unsafe/eval-record.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-large-unsafe-001",
+  "outcome": "success",
+  "what_worked": [
+    "route completed to long-run"
+  ],
+  "what_failed": []
+}

--- a/examples/runtime-fixtures/large-approved-but-unsafe/plan-ledger.json
+++ b/examples/runtime-fixtures/large-approved-but-unsafe/plan-ledger.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-large-unsafe-001",
+  "route": "large_high_risk",
+  "current_task_id": "task-3",
+  "tasks": [
+    {
+      "id": "task-1",
+      "title": "Plan migration",
+      "depends_on": [],
+      "files": [
+        "plan.json"
+      ],
+      "parallel_safe": true,
+      "status": "done",
+      "required_gates": [
+        "validator"
+      ],
+      "evidence_refs": [
+        "plan.json"
+      ],
+      "attempt_count": 0
+    },
+    {
+      "id": "task-2",
+      "title": "Execute migration changes with rollout caveats documented",
+      "depends_on": [
+        "task-1"
+      ],
+      "files": [
+        "review-report-spec.json",
+        "review-report-quality.json"
+      ],
+      "parallel_safe": false,
+      "status": "done",
+      "required_gates": [
+        "machine",
+        "validator",
+        "scenario"
+      ],
+      "evidence_refs": [
+        "review-report-spec.json",
+        "review-report-quality.json"
+      ],
+      "attempt_count": 1
+    },
+    {
+      "id": "task-3",
+      "title": "Capture long-run learnings before risky rollout",
+      "depends_on": [
+        "task-2"
+      ],
+      "files": [
+        "eval-record.json"
+      ],
+      "parallel_safe": false,
+      "status": "in_progress",
+      "required_gates": [
+        "validator"
+      ],
+      "evidence_refs": [],
+      "attempt_count": 0
+    }
+  ]
+}

--- a/examples/runtime-fixtures/large-approved-but-unsafe/plan.json
+++ b/examples/runtime-fixtures/large-approved-but-unsafe/plan.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-large-unsafe-001",
+  "steps": [
+    {
+      "id": "step-1",
+      "objective": "Plan migration",
+      "expected_output": "sequenced plan",
+      "verification": "review plan"
+    },
+    {
+      "id": "step-2",
+      "objective": "Execute migration changes",
+      "expected_output": "execution evidence captured",
+      "verification": "run orchestrator"
+    },
+    {
+      "id": "step-3",
+      "objective": "Capture long-run learnings",
+      "expected_output": "eval record present",
+      "verification": "inspect eval record"
+    }
+  ]
+}

--- a/examples/runtime-fixtures/large-approved-but-unsafe/review-report-quality.json
+++ b/examples/runtime-fixtures/large-approved-but-unsafe/review-report-quality.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-large-unsafe-001",
+  "review_type": "quality",
+  "verdict": "approved",
+  "findings": [
+    "quality review approved with explicit caution that rollout should stay gated until long-run evidence is captured"
+  ],
+  "approved_by": "quality-reviewer",
+  "next_action": "finalize 가능"
+}

--- a/examples/runtime-fixtures/large-approved-but-unsafe/review-report-spec.json
+++ b/examples/runtime-fixtures/large-approved-but-unsafe/review-report-spec.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-large-unsafe-001",
+  "review_type": "spec",
+  "verdict": "approved",
+  "findings": [
+    "spec review passed, but rollout sequencing remains sensitive"
+  ],
+  "approved_by": "spec-reviewer",
+  "next_action": "quality-review로 진행"
+}

--- a/examples/runtime-fixtures/medium-plan-with-weak-verification/README.md
+++ b/examples/runtime-fixtures/medium-plan-with-weak-verification/README.md
@@ -1,0 +1,3 @@
+# Medium runtime fixture with weak verification
+
+Medium route fixture that is structurally valid and resumable, but still represents work that should receive quality-review scrutiny before finalize.

--- a/examples/runtime-fixtures/medium-plan-with-weak-verification/brief.json
+++ b/examples/runtime-fixtures/medium-plan-with-weak-verification/brief.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-medium-weak-001",
+  "objective": "Refactor a medium route task that still has thin verification notes",
+  "in_scope": [
+    "runtime",
+    "tests"
+  ],
+  "out_of_scope": [
+    "provider integrations"
+  ],
+  "constraints": [
+    "local fixture only"
+  ],
+  "acceptance_criteria": [
+    "medium route completes"
+  ],
+  "risk_level": "medium"
+}

--- a/examples/runtime-fixtures/medium-plan-with-weak-verification/plan-ledger.json
+++ b/examples/runtime-fixtures/medium-plan-with-weak-verification/plan-ledger.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-medium-weak-001",
+  "route": "medium",
+  "current_task_id": "task-2",
+  "tasks": [
+    {
+      "id": "task-1",
+      "title": "Prepare bounded refactor plan with thin verification notes",
+      "depends_on": [],
+      "files": [
+        "plan.json"
+      ],
+      "parallel_safe": true,
+      "status": "done",
+      "required_gates": [
+        "validator"
+      ],
+      "evidence_refs": [
+        "plan.json"
+      ],
+      "attempt_count": 0
+    },
+    {
+      "id": "task-2",
+      "title": "Execute refactor with weak verification evidence",
+      "depends_on": [
+        "task-1"
+      ],
+      "files": [
+        "decision-log.json",
+        "run-state.json"
+      ],
+      "parallel_safe": false,
+      "status": "in_progress",
+      "required_gates": [
+        "machine",
+        "validator"
+      ],
+      "evidence_refs": [
+        "plan.json"
+      ],
+      "attempt_count": 2
+    }
+  ]
+}

--- a/examples/runtime-fixtures/medium-plan-with-weak-verification/plan.json
+++ b/examples/runtime-fixtures/medium-plan-with-weak-verification/plan.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-medium-weak-001",
+  "steps": [
+    {
+      "id": "step-1",
+      "objective": "Prepare refactor plan",
+      "expected_output": "plan recorded",
+      "verification": "review plan"
+    },
+    {
+      "id": "step-2",
+      "objective": "Execute bounded refactor",
+      "expected_output": "decision log and state written",
+      "verification": "run orchestrator"
+    }
+  ]
+}

--- a/examples/runtime-fixtures/medium-plan-with-weak-verification/review-report.json
+++ b/examples/runtime-fixtures/medium-plan-with-weak-verification/review-report.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-medium-weak-001",
+  "review_type": "quality",
+  "verdict": "approved",
+  "findings": [
+    "quality checks passed, but verification evidence remains intentionally light in this fixture"
+  ],
+  "approved_by": "quality-reviewer",
+  "next_action": "finalize 가능, 다만 실제 운영에서는 quality scrutiny 필요"
+}

--- a/examples/runtime-fixtures/negative/large-session-state-stale-review-ref/README.md
+++ b/examples/runtime-fixtures/negative/large-session-state-stale-review-ref/README.md
@@ -1,0 +1,3 @@
+# Negative large stale review ref fixture
+
+Large route fixture with a session-state/latest review pointer that references a missing review artifact.

--- a/examples/runtime-fixtures/negative/large-session-state-stale-review-ref/brief.json
+++ b/examples/runtime-fixtures/negative/large-session-state-stale-review-ref/brief.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-large-stale-ref-001",
+  "objective": "Run a large high-risk route fixture",
+  "in_scope": [
+    "runtime",
+    "docs"
+  ],
+  "out_of_scope": [
+    "live deployment"
+  ],
+  "constraints": [
+    "local fixture only"
+  ],
+  "acceptance_criteria": [
+    "large route completes including long-run"
+  ],
+  "risk_level": "high"
+}

--- a/examples/runtime-fixtures/negative/large-session-state-stale-review-ref/checkpoint.json
+++ b/examples/runtime-fixtures/negative/large-session-state-stale-review-ref/checkpoint.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-large-stale-ref-001",
+  "route": "large_high_risk",
+  "current_stage": "long-run",
+  "plan_ref": "plan.json",
+  "plan_ledger_ref": "plan-ledger.json",
+  "run_state_ref": "run-state.json",
+  "current_task_id": "task-3",
+  "latest_review_ref": "review-report-stale.json",
+  "next_action": "Resume at long-run after reloading canonical artifacts.",
+  "open_blockers": [],
+  "updated_at": "2026-04-23T07:00:00Z"
+}

--- a/examples/runtime-fixtures/negative/large-session-state-stale-review-ref/eval-record.json
+++ b/examples/runtime-fixtures/negative/large-session-state-stale-review-ref/eval-record.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-large-stale-ref-001",
+  "outcome": "success",
+  "what_worked": [
+    "route completed to long-run"
+  ],
+  "what_failed": []
+}

--- a/examples/runtime-fixtures/negative/large-session-state-stale-review-ref/plan-ledger.json
+++ b/examples/runtime-fixtures/negative/large-session-state-stale-review-ref/plan-ledger.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-large-stale-ref-001",
+  "route": "large_high_risk",
+  "current_task_id": "task-3",
+  "tasks": [
+    {
+      "id": "task-1",
+      "title": "Plan migration",
+      "depends_on": [],
+      "files": [
+        "plan.json"
+      ],
+      "parallel_safe": true,
+      "status": "done",
+      "required_gates": [
+        "validator"
+      ],
+      "evidence_refs": [
+        "plan.json"
+      ],
+      "attempt_count": 0
+    },
+    {
+      "id": "task-2",
+      "title": "Execute migration changes",
+      "depends_on": [
+        "task-1"
+      ],
+      "files": [
+        "review-report-spec.json",
+        "review-report-quality.json"
+      ],
+      "parallel_safe": false,
+      "status": "done",
+      "required_gates": [
+        "machine",
+        "validator",
+        "scenario"
+      ],
+      "evidence_refs": [
+        "review-report-spec.json",
+        "review-report-quality.json"
+      ],
+      "attempt_count": 1
+    },
+    {
+      "id": "task-3",
+      "title": "Capture long-run learnings",
+      "depends_on": [
+        "task-2"
+      ],
+      "files": [
+        "eval-record.json"
+      ],
+      "parallel_safe": false,
+      "status": "in_progress",
+      "required_gates": [
+        "validator"
+      ],
+      "evidence_refs": [],
+      "attempt_count": 0
+    }
+  ]
+}

--- a/examples/runtime-fixtures/negative/large-session-state-stale-review-ref/plan.json
+++ b/examples/runtime-fixtures/negative/large-session-state-stale-review-ref/plan.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-large-stale-ref-001",
+  "steps": [
+    {
+      "id": "step-1",
+      "objective": "Plan migration",
+      "expected_output": "sequenced plan",
+      "verification": "review plan"
+    },
+    {
+      "id": "step-2",
+      "objective": "Execute migration changes",
+      "expected_output": "execution evidence captured",
+      "verification": "run orchestrator"
+    },
+    {
+      "id": "step-3",
+      "objective": "Capture long-run learnings",
+      "expected_output": "eval record present",
+      "verification": "inspect eval record"
+    }
+  ]
+}

--- a/examples/runtime-fixtures/negative/large-session-state-stale-review-ref/review-report-quality.json
+++ b/examples/runtime-fixtures/negative/large-session-state-stale-review-ref/review-report-quality.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-large-stale-ref-001",
+  "review_type": "quality",
+  "verdict": "approved",
+  "findings": [
+    "quality review passed for large route fixture"
+  ],
+  "approved_by": "quality-reviewer",
+  "next_action": "finalize 가능"
+}

--- a/examples/runtime-fixtures/negative/large-session-state-stale-review-ref/review-report-spec.json
+++ b/examples/runtime-fixtures/negative/large-session-state-stale-review-ref/review-report-spec.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-large-stale-ref-001",
+  "review_type": "spec",
+  "verdict": "approved",
+  "findings": [
+    "spec review passed for large route fixture"
+  ],
+  "approved_by": "spec-reviewer",
+  "next_action": "quality-review로 진행"
+}

--- a/examples/runtime-fixtures/negative/large-session-state-stale-review-ref/run-state.json
+++ b/examples/runtime-fixtures/negative/large-session-state-stale-review-ref/run-state.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-large-stale-ref-001",
+  "current_stage": "long-run",
+  "status": "in_progress",
+  "completed_gates": [
+    "clarification_complete",
+    "planning_complete",
+    "implementation_complete",
+    "spec_review_passed",
+    "quality_review_passed"
+  ],
+  "failed_gates": [],
+  "retries": {},
+  "evidence_refs": [
+    "review-report-spec.json",
+    "review-report-quality.json"
+  ],
+  "current_task_id": "task-3",
+  "spec_review_approved": true,
+  "quality_review_approved": true
+}

--- a/examples/runtime-fixtures/negative/large-session-state-stale-review-ref/session-state.json
+++ b/examples/runtime-fixtures/negative/large-session-state-stale-review-ref/session-state.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-large-stale-ref-001",
+  "route": "large_high_risk",
+  "current_stage": "long-run",
+  "plan_ref": "plan.json",
+  "plan_ledger_ref": "plan-ledger.json",
+  "run_state_ref": "run-state.json",
+  "latest_checkpoint_ref": "checkpoint.json",
+  "current_task_id": "task-3",
+  "latest_review_ref": "review-report-stale.json",
+  "next_action": "Resume at long-run after reloading canonical artifacts.",
+  "updated_at": "2026-04-23T07:00:00Z"
+}

--- a/examples/runtime-fixtures/negative/large-spec-quality-mismatch/README.md
+++ b/examples/runtime-fixtures/negative/large-spec-quality-mismatch/README.md
@@ -1,0 +1,3 @@
+# Negative large spec/quality mismatch fixture
+
+Large route fixture where the spec review artifact is wrong-type, so quality approval cannot substitute for the spec-review gate.

--- a/examples/runtime-fixtures/negative/large-spec-quality-mismatch/brief.json
+++ b/examples/runtime-fixtures/negative/large-spec-quality-mismatch/brief.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-large-mismatch-001",
+  "objective": "Run a large high-risk route fixture",
+  "in_scope": [
+    "runtime",
+    "docs"
+  ],
+  "out_of_scope": [
+    "live deployment"
+  ],
+  "constraints": [
+    "local fixture only"
+  ],
+  "acceptance_criteria": [
+    "large route completes including long-run"
+  ],
+  "risk_level": "high"
+}

--- a/examples/runtime-fixtures/negative/large-spec-quality-mismatch/eval-record.json
+++ b/examples/runtime-fixtures/negative/large-spec-quality-mismatch/eval-record.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-large-mismatch-001",
+  "outcome": "success",
+  "what_worked": [
+    "route completed to long-run"
+  ],
+  "what_failed": []
+}

--- a/examples/runtime-fixtures/negative/large-spec-quality-mismatch/plan-ledger.json
+++ b/examples/runtime-fixtures/negative/large-spec-quality-mismatch/plan-ledger.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-large-mismatch-001",
+  "route": "large_high_risk",
+  "current_task_id": "task-3",
+  "tasks": [
+    {
+      "id": "task-1",
+      "title": "Plan migration",
+      "depends_on": [],
+      "files": [
+        "plan.json"
+      ],
+      "parallel_safe": true,
+      "status": "done",
+      "required_gates": [
+        "validator"
+      ],
+      "evidence_refs": [
+        "plan.json"
+      ],
+      "attempt_count": 0
+    },
+    {
+      "id": "task-2",
+      "title": "Execute migration changes",
+      "depends_on": [
+        "task-1"
+      ],
+      "files": [
+        "review-report-spec.json",
+        "review-report-quality.json"
+      ],
+      "parallel_safe": false,
+      "status": "done",
+      "required_gates": [
+        "machine",
+        "validator",
+        "scenario"
+      ],
+      "evidence_refs": [
+        "review-report-spec.json",
+        "review-report-quality.json"
+      ],
+      "attempt_count": 1
+    },
+    {
+      "id": "task-3",
+      "title": "Capture long-run learnings",
+      "depends_on": [
+        "task-2"
+      ],
+      "files": [
+        "eval-record.json"
+      ],
+      "parallel_safe": false,
+      "status": "in_progress",
+      "required_gates": [
+        "validator"
+      ],
+      "evidence_refs": [],
+      "attempt_count": 0
+    }
+  ]
+}

--- a/examples/runtime-fixtures/negative/large-spec-quality-mismatch/plan.json
+++ b/examples/runtime-fixtures/negative/large-spec-quality-mismatch/plan.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-large-mismatch-001",
+  "steps": [
+    {
+      "id": "step-1",
+      "objective": "Plan migration",
+      "expected_output": "sequenced plan",
+      "verification": "review plan"
+    },
+    {
+      "id": "step-2",
+      "objective": "Execute migration changes",
+      "expected_output": "execution evidence captured",
+      "verification": "run orchestrator"
+    },
+    {
+      "id": "step-3",
+      "objective": "Capture long-run learnings",
+      "expected_output": "eval record present",
+      "verification": "inspect eval record"
+    }
+  ]
+}

--- a/examples/runtime-fixtures/negative/large-spec-quality-mismatch/review-report-quality.json
+++ b/examples/runtime-fixtures/negative/large-spec-quality-mismatch/review-report-quality.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-large-mismatch-001",
+  "review_type": "quality",
+  "verdict": "approved",
+  "findings": [
+    "quality approval exists but must not satisfy the spec-review gate"
+  ],
+  "approved_by": "quality-reviewer",
+  "next_action": "finalize 가능"
+}

--- a/examples/runtime-fixtures/negative/large-spec-quality-mismatch/review-report-spec.json
+++ b/examples/runtime-fixtures/negative/large-spec-quality-mismatch/review-report-spec.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-large-mismatch-001",
+  "review_type": "quality",
+  "verdict": "approved",
+  "findings": [
+    "wrong review type on spec-review artifact to prove substitution is rejected"
+  ],
+  "approved_by": "spec-reviewer",
+  "next_action": "quality-review로 진행"
+}

--- a/examples/runtime-fixtures/negative/medium-ledger-gate-drift/README.md
+++ b/examples/runtime-fixtures/negative/medium-ledger-gate-drift/README.md
@@ -1,0 +1,3 @@
+# Negative medium ledger gate drift fixture
+
+Medium route fixture where the plan ledger claims a future gate was completed before the route reached that stage.

--- a/examples/runtime-fixtures/negative/medium-ledger-gate-drift/brief.json
+++ b/examples/runtime-fixtures/negative/medium-ledger-gate-drift/brief.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-medium-drift-001",
+  "objective": "Run a medium route fixture",
+  "in_scope": [
+    "runtime",
+    "tests"
+  ],
+  "out_of_scope": [
+    "provider integrations"
+  ],
+  "constraints": [
+    "local fixture only"
+  ],
+  "acceptance_criteria": [
+    "medium route completes"
+  ],
+  "risk_level": "medium"
+}

--- a/examples/runtime-fixtures/negative/medium-ledger-gate-drift/plan-ledger.json
+++ b/examples/runtime-fixtures/negative/medium-ledger-gate-drift/plan-ledger.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-medium-drift-001",
+  "route": "medium",
+  "current_task_id": "task-2",
+  "tasks": [
+    {
+      "id": "task-1",
+      "title": "Prepare refactor plan",
+      "depends_on": [],
+      "files": [
+        "plan.json"
+      ],
+      "parallel_safe": true,
+      "status": "done",
+      "required_gates": [
+        "validator"
+      ],
+      "evidence_refs": [
+        "plan.json"
+      ],
+      "attempt_count": 0
+    },
+    {
+      "id": "task-2",
+      "title": "Execute bounded refactor",
+      "depends_on": [
+        "task-1"
+      ],
+      "files": [
+        "decision-log.json",
+        "run-state.json"
+      ],
+      "parallel_safe": false,
+      "status": "in_progress",
+      "required_gates": [
+        "machine",
+        "validator"
+      ],
+      "evidence_refs": [],
+      "attempt_count": 1
+    }
+  ],
+  "completed_gates": [
+    "clarification_complete",
+    "implementation_complete",
+    "quality_review_passed"
+  ]
+}

--- a/examples/runtime-fixtures/negative/medium-ledger-gate-drift/plan.json
+++ b/examples/runtime-fixtures/negative/medium-ledger-gate-drift/plan.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-medium-drift-001",
+  "steps": [
+    {
+      "id": "step-1",
+      "objective": "Prepare refactor plan",
+      "expected_output": "plan recorded",
+      "verification": "review plan"
+    },
+    {
+      "id": "step-2",
+      "objective": "Execute bounded refactor",
+      "expected_output": "decision log and state written",
+      "verification": "run orchestrator"
+    }
+  ]
+}

--- a/examples/runtime-fixtures/negative/medium-ledger-gate-drift/review-report.json
+++ b/examples/runtime-fixtures/negative/medium-ledger-gate-drift/review-report.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-medium-drift-001",
+  "review_type": "quality",
+  "verdict": "approved",
+  "findings": [
+    "quality checks passed for medium route fixture"
+  ],
+  "approved_by": "quality-reviewer",
+  "next_action": "finalize 가능"
+}

--- a/scripts/run_adherence_evals.py
+++ b/scripts/run_adherence_evals.py
@@ -71,7 +71,9 @@ def main() -> int:
             scenarios.append(_positive_case('small-doc-task', fixtures_root / 'small-doc-task', 'small', 'finalize', workspace))
             scenarios.append(_positive_case('resume-small-task', fixtures_root / 'resume-small-task', 'small', 'finalize', workspace))
             scenarios.append(_positive_case('medium-refactor-task', fixtures_root / 'medium-refactor-task', 'medium', 'finalize', workspace))
+            scenarios.append(_positive_case('medium-plan-with-weak-verification', fixtures_root / 'medium-plan-with-weak-verification', 'medium', 'finalize', workspace))
             scenarios.append(_positive_case('large-migration-task', fixtures_root / 'large-migration-task', 'large_high_risk', 'long-run', workspace))
+            scenarios.append(_positive_case('large-approved-but-unsafe', fixtures_root / 'large-approved-but-unsafe', 'large_high_risk', 'long-run', workspace))
             negative_root = fixtures_root / 'negative'
             scenarios.append(_negative_run_case('missing-quality-approval', negative_root / 'missing-quality-approval', 'small', 'quality-review requires approved quality review-report artifact', workspace))
             scenarios.append(_negative_run_case('invalid-review-report', negative_root / 'invalid-review-report', 'small', 'review-report.json failed schema validation', workspace))
@@ -82,6 +84,9 @@ def main() -> int:
             scenarios.append(_negative_run_case('checkpoint-gate-drift', negative_root / 'checkpoint-gate-drift', 'small', 'run-state checkpoint is missing completed gates before execute: clarification_complete', workspace))
             scenarios.append(_negative_run_case('future-gate-checkpoint-drift', negative_root / 'future-gate-checkpoint-drift', 'small', 'run-state checkpoint has out-of-sequence completed gates at execute: quality_review_passed', workspace))
             scenarios.append(_negative_run_case('completed-checkpoint-drift', negative_root / 'completed-checkpoint-drift', 'small', 'completed run-state checkpoint must already be at terminal stage finalize', workspace))
+            scenarios.append(_negative_run_case('medium-ledger-gate-drift', negative_root / 'medium-ledger-gate-drift', 'medium', 'plan-ledger checkpoint has out-of-sequence completed gates at clarify: quality_review_passed', workspace))
+            scenarios.append(_negative_run_case('large-spec-quality-mismatch', negative_root / 'large-spec-quality-mismatch', 'large_high_risk', 'spec-review requires approved spec review-report artifact', workspace))
+            scenarios.append(_negative_run_case('large-session-state-stale-review-ref', negative_root / 'large-session-state-stale-review-ref', 'large_high_risk', 'checkpoint.json latest_review_ref review-report-stale.json does not exist', workspace))
     except Exception as exc:
         print('ADHERENCE EVALS: FAIL')
         print(f'- {exc}')

--- a/tests/test_runtime_orchestrator.py
+++ b/tests/test_runtime_orchestrator.py
@@ -2088,7 +2088,9 @@ def test_medium_and_large_runtime_fixtures_run_end_to_end(tmp_path: Path) -> Non
 
     for fixture_name, route_name, expected_stage in [
         ("medium-refactor-task", "medium", "finalize"),
+        ("medium-plan-with-weak-verification", "medium", "finalize"),
         ("large-migration-task", "large_high_risk", "long-run"),
+        ("large-approved-but-unsafe", "large_high_risk", "long-run"),
     ]:
         source_dir = fixtures_root / fixture_name
         task_dir = tmp_path / fixture_name
@@ -2114,7 +2116,9 @@ def test_adherence_eval_cli_runs_valid_and_negative_fixtures() -> None:
     assert "small-doc-task" in result.stdout
     assert "resume-small-task" in result.stdout
     assert "medium-refactor-task" in result.stdout
+    assert "medium-plan-with-weak-verification" in result.stdout
     assert "large-migration-task" in result.stdout
+    assert "large-approved-but-unsafe" in result.stdout
     assert "missing-quality-approval" in result.stdout
     assert "invalid-review-report" in result.stdout
     assert "missing-run-state-before-spec-review" in result.stdout
@@ -2124,3 +2128,6 @@ def test_adherence_eval_cli_runs_valid_and_negative_fixtures() -> None:
     assert "checkpoint-gate-drift" in result.stdout
     assert "future-gate-checkpoint-drift" in result.stdout
     assert "completed-checkpoint-drift" in result.stdout
+    assert "medium-ledger-gate-drift" in result.stdout
+    assert "large-spec-quality-mismatch" in result.stdout
+    assert "large-session-state-stale-review-ref" in result.stdout


### PR DESCRIPTION
## Summary
- add richer medium/large positive fixtures for status and review coverage
- add negative fixtures for medium ledger drift, large spec/quality mismatch, and stale large-route review refs
- wire the new fixture set into adherence evals and runtime tests
- document the expanded eval surface

## Verification
- [x] `pytest -q tests/test_runtime_orchestrator.py -k 'medium_and_large_runtime_fixtures_run_end_to_end or adherence_eval_cli_runs_valid_and_negative_fixtures'`
- [x] `python3 scripts/validate_sample_artifacts.py`
- [x] `python3 scripts/run_adherence_evals.py`
- [x] `make validate`

Closes #18
