### PR TITLE
fix: generalize safe-for-next-stage semantics

### DIFF
--- a/docs/plans/2026-04-23-operator-workflow-gap-closure.md
+++ b/docs/plans/2026-04-23-operator-workflow-gap-closure.md
@@ -270,7 +270,7 @@ Quality review must distinguish:
 ### Verification
 - `python3 scripts/validate_sample_artifacts.py`
 - negative samples fail for malformed severity structure
-- runtime/finalize respects `safe_for_next_stage`
+- runtime/finalize treats `safe_for_next_stage` as a generic approved-review progression guard, not a quality-only flag
 
 ### Why this matters
 Superpowers got one thing very right: review should be skeptical.

--- a/docs/plans/2026-04-23-runtime-hardening-next-slice.md
+++ b/docs/plans/2026-04-23-runtime-hardening-next-slice.md
@@ -49,7 +49,7 @@ Catch semantic drift inside the runtime itself instead of relying on docs/tests 
    - `review_type=spec` cannot satisfy quality-review gate
    - `review_type=quality` cannot satisfy spec-review gate
    - `verdict=approved` with unresolved blockers should fail runtime validation once blockers are modeled explicitly in the artifact contract
-   - `safe_for_next_stage=false` must block finalize/next-stage progress once that field exists in the review-report contract
+   - any `verdict=approved` review artifact must not set `safe_for_next_stage=false`; that flag is a generic progression blocker, not a quality-review-only escape hatch
 
 3. **Plan-ledger consistency checks**
    - completed stages must respect route order

--- a/examples/artifacts/review-report-approved-spec-unsafe.sample.json
+++ b/examples/artifacts/review-report-approved-spec-unsafe.sample.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "0.1",
+  "task_id": "task-001",
+  "review_type": "spec",
+  "verdict": "approved",
+  "findings": [
+    "spec is approved but still marked unsafe for the next stage"
+  ],
+  "approved_by": "spec-reviewer",
+  "safe_for_next_stage": false,
+  "next_action": "quality-review 보류"
+}

--- a/forgeflow_runtime/orchestrator.py
+++ b/forgeflow_runtime/orchestrator.py
@@ -412,14 +412,13 @@ def _load_session_state(task_dir: Path, *, canonical_task_id: str) -> dict[str, 
 
 def _validate_review_semantics(payload: dict[str, Any], *, source_name: str) -> None:
     verdict = payload.get("verdict")
-    review_type = payload.get("review_type")
     open_blockers = payload.get("open_blockers", [])
     if open_blockers is None:
         open_blockers = []
     if verdict == "approved" and open_blockers:
         raise RuntimeViolation(f"approved {source_name} cannot declare open_blockers")
-    if review_type == "quality" and verdict == "approved" and payload.get("safe_for_next_stage") is False:
-        raise RuntimeViolation(f"quality {source_name} approved verdict cannot set safe_for_next_stage=false")
+    if verdict == "approved" and payload.get("safe_for_next_stage") is False:
+        raise RuntimeViolation(f"approved {source_name} cannot set safe_for_next_stage=false")
 
 
 def _expected_plan_ledger_ref(*, route_name: str, plan_ledger: dict[str, Any] | None) -> str:

--- a/tests/test_runtime_orchestrator.py
+++ b/tests/test_runtime_orchestrator.py
@@ -509,7 +509,28 @@ def test_run_route_rejects_approved_quality_review_marked_unsafe(tmp_path: Path)
         },
     )
 
-    with pytest.raises(RuntimeViolation, match="quality review-report.json approved verdict cannot set safe_for_next_stage=false"):
+    with pytest.raises(RuntimeViolation, match="approved review-report.json cannot set safe_for_next_stage=false"):
+        run_route(task_dir=task_dir, policy=policy, route_name="small")
+
+
+def test_run_route_rejects_approved_spec_review_marked_unsafe(tmp_path: Path) -> None:
+    policy = load_runtime_policy(ROOT)
+    task_dir = _make_task_dir(tmp_path)
+    _write_json(
+        task_dir / "review-report.json",
+        {
+            "schema_version": "0.1",
+            "task_id": "task-001",
+            "review_type": "spec",
+            "verdict": "approved",
+            "findings": ["spec is approved but rollout is still unsafe"],
+            "approved_by": "spec-reviewer",
+            "safe_for_next_stage": False,
+            "next_action": "quality-review 보류",
+        },
+    )
+
+    with pytest.raises(RuntimeViolation, match="approved review-report.json cannot set safe_for_next_stage=false"):
         run_route(task_dir=task_dir, policy=policy, route_name="small")
 
 


### PR DESCRIPTION
## Summary
- generalize `safe_for_next_stage=false` from quality-only handling to all approved review artifacts
- add runtime tests proving both approved quality and approved spec reviews are rejected when marked unsafe
- add a sample artifact and document the clarified contract semantics

## Verification
- [x] `pytest -q tests/test_runtime_orchestrator.py -k 'approved_review_with_open_blockers or approved_quality_review_marked_unsafe or approved_spec_review_marked_unsafe'`
- [x] `python3 scripts/validate_sample_artifacts.py`
- [x] `make validate`

Closes #22
