### PR TITLE
feat: clarify clarify-first workflow and fallback auto routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ It is a repo seed for running work through explicit stages, artifacts, gates, an
 - keeps small tasks light and high-risk tasks strict
 
 ## Core workflow
+ForgeFlow의 정본 시작점은 항상 `clarify`다.
+
 1. `clarify`
 2. `plan`
 3. `execute`
@@ -21,7 +23,13 @@ It is a repo seed for running work through explicit stages, artifacts, gates, an
 6. `finalize`
 7. `long-run`
 
+`clarify`는 요청을 실행 가능한 brief로 정리하고, 필요한 route를 결정하는 기본 입구다. 사용자가 정상 경로로 들어오면 여기서 시작하는 게 맞다.
+
+아무 state도 없는데 operator가 `start`/`run`으로 바로 진입하는 경우는 예외다. 이때만 runtime이 fallback으로 auto routing을 적용할 수 있다. 다만 이건 convenience layer일 뿐이고, workflow 의미론의 본체는 여전히 `clarify-first`다.
+
 ## Complexity routing
+fallback auto routing이 route를 고르면 canonical policy는 아래 순서를 따른다.
+
 - **small** → `clarify -> execute -> quality-review -> finalize`
 - **medium** → `clarify -> plan -> execute -> quality-review -> finalize`
 - **large/high-risk** → `clarify -> plan -> execute -> spec-review -> quality-review -> finalize -> long-run`
@@ -58,8 +66,12 @@ make runtime-sample
 ```
 
 ## Runtime sample
+권장 경로는 `clarify`부터 brief와 route를 만든 뒤 진행하는 것이다. 아래 CLI 예시는 local runtime을 직접 만질 때 쓰는 operator surface다.
+
 ```bash
 python3 scripts/run_runtime_sample.py --fixture-dir examples/runtime-fixtures/small-doc-task --route small
+python3 scripts/run_orchestrator.py run --task-dir examples/runtime-fixtures/small-doc-task
+python3 scripts/run_orchestrator.py run --task-dir examples/runtime-fixtures/small-doc-task --min-route medium
 python3 scripts/run_orchestrator.py execute --task-dir examples/runtime-fixtures/small-doc-task --route small --adapter codex
 python3 scripts/run_orchestrator.py advance --task-dir examples/runtime-fixtures/small-doc-task --route small --current-stage clarify
 python3 scripts/run_orchestrator.py advance --task-dir examples/runtime-fixtures/small-doc-task --route small --current-stage clarify --execute --adapter cursor
@@ -70,7 +82,7 @@ python3 scripts/run_orchestrator.py escalate --task-dir examples/runtime-fixture
 
 `run_runtime_sample.py`는 fixture를 임시 workspace로 복사한 뒤 실행해서 샘플 명령만으로 tracked runtime fixture가 dirty 상태가 되지 않게 막는다. 실행 결과에는 원본 fixture 경로만 다시 싣고, 임시 workspace 경로는 노출하지 않는다. manual `execute`/`advance`/`retry` 예시는 여전히 원본 task-dir를 직접 대상으로 삼지만, `run` 샘플은 disposable copy에서만 돈다.
 
-이 CLI는 local artifact 디렉터리를 기준으로 route 실행과 recovery helper를 노출한다. `run`은 artifact/gate 기준으로 route 상태를 진행하는 orchestration 명령이고, `execute`는 현재 stage를 어댑터로 실행한다. `advance --execute`는 다음 stage로 넘긴 뒤 바로 실행까지 붙이되, 실행이 실패하면 stage pointer를 커밋하지 않는다. medium/large route에서는 `advance`/`run` 모두 `plan-ledger.json`이 있어야 하고, `step-back`은 되감는 stage에 해당하는 review approval/evidence만 지운다. 정책 위반이나 잘못된 route가 들어오면 traceback 대신 `ERROR:` 형식의 명시적 runtime 오류를 반환한다.
+이 CLI는 local artifact 디렉터리를 기준으로 route 실행과 recovery helper를 노출한다. `run`은 artifact/gate 기준으로 route 상태를 진행하는 orchestration 명령이다. `run`/`start`는 operator fallback surface라서, route를 명시하지 않으면 persisted state를 재사용하거나 brief/checkpoint 기준으로 auto routing을 시도한다. 그래도 workflow의 정본은 여전히 `clarify-first`다. `execute`는 현재 stage를 어댑터로 실행한다. `advance --execute`는 다음 stage로 넘긴 뒤 바로 실행까지 붙이되, 실행이 실패하면 stage pointer를 커밋하지 않는다. medium/large route에서는 `advance`/`run` 모두 `plan-ledger.json`이 있어야 하고, `step-back`은 되감는 stage에 해당하는 review approval/evidence만 지운다. 정책 위반이나 잘못된 route가 들어오면 traceback 대신 `ERROR:` 형식의 명시적 runtime 오류를 반환한다.
 
 ## Using ForgeFlow in Codex
 Codex에서는 repo 루트의 `CODEX.md`가 지속 표면이다. generated adapter를 그대로 복사해서 쓰고, 프로젝트별 보조 규칙은 별도 문서에 두는 게 맞다. generated 파일을 손으로 덕지덕지 고치기 시작하면 다음 regenerate 때 다시 개판 난다.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -140,6 +140,10 @@
 
 ## 2. Complexity routing
 
+기본 경로는 `clarify-first`다. 즉, 정상 진입은 항상 `clarify`에서 시작하고 여기서 brief와 route를 정한다.
+
+다만 operator가 아무 state 없이 runtime `start`/`run`에 바로 들어오면 fallback auto routing이 route를 고를 수 있다. 이 경우에도 선택된 route의 첫 stage는 여전히 `clarify`이며, auto routing은 정본 workflow를 대체하지 않는다.
+
 ### small
 `clarify -> execute -> quality-review -> finalize`
 

--- a/scripts/run_orchestrator.py
+++ b/scripts/run_orchestrator.py
@@ -55,6 +55,13 @@ STAGE_ROLE_MAP: dict[str, str] = {
     "long-run": "worker",
 }
 
+ROUTE_ORDER: list[str] = ["small", "medium", "large_high_risk"]
+RISK_TO_ROUTE: dict[str, str] = {
+    "low": "small",
+    "medium": "medium",
+    "high": "large_high_risk",
+}
+
 
 def _role_for_stage(stage: str) -> str:
     role = STAGE_ROLE_MAP.get(stage)
@@ -63,29 +70,81 @@ def _role_for_stage(stage: str) -> str:
     return role
 
 
+def _route_rank(route_name: str) -> int:
+    if route_name not in ROUTE_ORDER:
+        raise RuntimeViolation(f"unknown route: {route_name}")
+    return ROUTE_ORDER.index(route_name)
+
+
+def _auto_route_for_task_dir(task_dir: Path) -> str:
+    for artifact_name in ["session-state.json", "checkpoint.json", "plan-ledger.json"]:
+        path = task_dir / artifact_name
+        if not path.exists():
+            continue
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        route_name = payload.get("route")
+        if isinstance(route_name, str) and route_name:
+            return route_name
+
+    brief_path = task_dir / "brief.json"
+    if brief_path.exists():
+        brief = json.loads(brief_path.read_text(encoding="utf-8"))
+        risk_level = brief.get("risk_level")
+        if isinstance(risk_level, str) and risk_level in RISK_TO_ROUTE:
+            return RISK_TO_ROUTE[risk_level]
+
+    return "small"
+
+
+def _effective_route(*, task_dir: Path, explicit_route: str | None, min_route: str | None) -> str:
+    route_name = explicit_route or _auto_route_for_task_dir(task_dir)
+    if min_route is None:
+        return route_name
+    return ROUTE_ORDER[max(_route_rank(route_name), _route_rank(min_route))]
+
+
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="ForgeFlow minimal stage-machine orchestrator")
+    parser = argparse.ArgumentParser(
+        description=(
+            "ForgeFlow stage-machine orchestrator. Preferred entry is clarify-first; direct start/run is a fallback "
+            "operator path that can auto-detect a route when no state exists."
+        )
+    )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    start_parser = subparsers.add_parser("start", help="initialize a new task directory with route-owned artifacts")
-    start_parser.add_argument("--task-dir", required=True)
-    start_parser.add_argument("--route", required=True)
+    route_help = "explicit route override; omit to reuse persisted route or auto-detect from brief/checkpoint state"
+    min_route_help = "minimum allowed route when auto-detecting or reusing state; never lowers an explicit or persisted route"
 
-    run_parser = subparsers.add_parser("run", help="run an entire route end-to-end")
+    start_parser = subparsers.add_parser(
+        "start",
+        help="initialize task artifacts; fallback path when operator starts outside clarify",
+    )
+    start_parser.add_argument("--task-dir", required=True)
+    start_parser.add_argument("--route", help=route_help)
+    start_parser.add_argument("--min-route", choices=ROUTE_ORDER, help=min_route_help)
+
+    run_parser = subparsers.add_parser(
+        "run",
+        help="run a route end-to-end; fallback path can auto-route when no prior state exists",
+    )
     run_parser.add_argument("--task-dir", required=True)
-    run_parser.add_argument("--route", required=True)
+    run_parser.add_argument("--route", help=route_help)
+    run_parser.add_argument("--min-route", choices=ROUTE_ORDER, help=min_route_help)
 
     resume_parser = subparsers.add_parser("resume", help="reload task state from session-state and checkpoint artifacts")
     resume_parser.add_argument("--task-dir", required=True)
-    resume_parser.add_argument("--route", required=True)
+    resume_parser.add_argument("--route", help=route_help)
+    resume_parser.add_argument("--min-route", choices=ROUTE_ORDER, help=min_route_help)
 
     status_parser = subparsers.add_parser("status", help="show current task status from canonical artifacts")
     status_parser.add_argument("--task-dir", required=True)
-    status_parser.add_argument("--route", required=True)
+    status_parser.add_argument("--route", help=route_help)
+    status_parser.add_argument("--min-route", choices=ROUTE_ORDER, help=min_route_help)
 
     advance_parser = subparsers.add_parser("advance", help="advance one stage forward")
     advance_parser.add_argument("--task-dir", required=True)
-    advance_parser.add_argument("--route", required=True)
+    advance_parser.add_argument("--route", help=route_help)
+    advance_parser.add_argument("--min-route", choices=ROUTE_ORDER, help=min_route_help)
     advance_parser.add_argument("--current-stage", required=True)
     advance_parser.add_argument("--execute", action="store_true", help="execute the next stage immediately after advancing")
     advance_parser.add_argument("--adapter", choices=["claude", "codex", "cursor"], default="claude")
@@ -100,7 +159,8 @@ def build_parser() -> argparse.ArgumentParser:
 
     step_back_parser = subparsers.add_parser("step-back", help="rewind to the previous stage")
     step_back_parser.add_argument("--task-dir", required=True)
-    step_back_parser.add_argument("--route", required=True)
+    step_back_parser.add_argument("--route", help=route_help)
+    step_back_parser.add_argument("--min-route", choices=ROUTE_ORDER, help=min_route_help)
     step_back_parser.add_argument("--current-stage", required=True)
 
     escalate_parser = subparsers.add_parser("escalate", help="escalate a route to large_high_risk")
@@ -109,7 +169,8 @@ def build_parser() -> argparse.ArgumentParser:
 
     exec_parser = subparsers.add_parser("execute", help="execute the current stage via an LLM adapter")
     exec_parser.add_argument("--task-dir", required=True)
-    exec_parser.add_argument("--route", required=True)
+    exec_parser.add_argument("--route", help=route_help)
+    exec_parser.add_argument("--min-route", choices=ROUTE_ORDER, help=min_route_help)
     exec_parser.add_argument("--adapter", choices=["claude", "codex", "cursor"], default="claude")
     exec_parser.add_argument("--role", default=None, help="override role (auto-detected from stage if omitted)")
     exec_parser.add_argument("--artifacts", nargs="+", default=None, help="artifact names to stream")
@@ -125,19 +186,24 @@ def main() -> int:
     policy = load_runtime_policy(ROOT)
 
     try:
+        route_name = _effective_route(
+            task_dir=task_dir,
+            explicit_route=getattr(args, "route", None),
+            min_route=getattr(args, "min_route", None),
+        )
         if args.command == "start":
-            _print_payload(start_task(task_dir=task_dir, policy=policy, route_name=args.route))
+            _print_payload(start_task(task_dir=task_dir, policy=policy, route_name=route_name))
         elif args.command == "run":
-            _print_payload(run_route(task_dir=task_dir, policy=policy, route_name=args.route))
+            _print_payload(run_route(task_dir=task_dir, policy=policy, route_name=route_name))
         elif args.command == "resume":
-            _print_payload(resume_task(task_dir=task_dir, policy=policy, route_name=args.route))
+            _print_payload(resume_task(task_dir=task_dir, policy=policy, route_name=route_name))
         elif args.command == "status":
-            _print_payload(status_summary(task_dir=task_dir, policy=policy, route_name=args.route))
+            _print_payload(status_summary(task_dir=task_dir, policy=policy, route_name=route_name))
         elif args.command == "advance":
             transition = advance_to_next_stage(
                 task_dir=task_dir,
                 policy=policy,
-                route_name=args.route,
+                route_name=route_name,
                 current_stage=args.current_stage,
                 execute_immediately=args.execute,
                 adapter_target=args.adapter,
@@ -153,7 +219,7 @@ def main() -> int:
             _print_payload(retry_stage(task_dir=task_dir, stage_name=args.stage, max_retries=args.max_retries))
         elif args.command == "step-back":
             _print_payload(
-                step_back(task_dir=task_dir, policy=policy, route_name=args.route, current_stage=args.current_stage)
+                step_back(task_dir=task_dir, policy=policy, route_name=route_name, current_stage=args.current_stage)
             )
         elif args.command == "escalate":
             _print_payload(escalate_route(task_dir=task_dir, from_route=args.from_route))
@@ -172,7 +238,7 @@ def main() -> int:
                 task_dir=task_dir,
                 task_id=run_state.get("task_id", "unknown"),
                 stage=current_stage,
-                route=args.route,
+                route=route_name,
                 role=role,
                 adapter_target=args.adapter,
                 artifacts_to_stream=args.artifacts,

--- a/tests/test_runtime_orchestrator.py
+++ b/tests/test_runtime_orchestrator.py
@@ -1993,6 +1993,55 @@ def test_cli_supports_start_resume_and_status(tmp_path: Path) -> None:
     assert json.loads(resume_result.stdout)["route"] == "medium"
 
 
+def test_cli_start_supports_min_route_override_without_explicit_route(tmp_path: Path) -> None:
+    task_dir = tmp_path / "cli-min-route-start"
+
+    start_result = _run_orchestrator_cli("start", "--task-dir", str(task_dir), "--min-route", "medium")
+
+    assert start_result.returncode == 0
+    payload = json.loads(start_result.stdout)
+    assert payload["route"] == "medium"
+
+
+def test_cli_run_auto_detects_small_route_and_min_route_can_raise_it(tmp_path: Path) -> None:
+    task_dir = tmp_path / "cli-auto-route"
+    task_dir.mkdir()
+    _write_json(
+        task_dir / "brief.json",
+        {
+            "schema_version": "0.1",
+            "task_id": "task-auto-001",
+            "objective": "Auto route selection",
+            "in_scope": ["runtime"],
+            "out_of_scope": [],
+            "constraints": ["local only"],
+            "acceptance_criteria": ["auto route works"],
+            "risk_level": "low",
+        },
+    )
+    _write_json(
+        task_dir / "review-report.json",
+        {
+            "schema_version": "0.1",
+            "task_id": "task-auto-001",
+            "review_type": "quality",
+            "verdict": "approved",
+            "findings": ["cli looks fine"],
+            "approved_by": "quality-reviewer",
+            "next_action": "finalize 가능",
+        },
+    )
+
+    auto_result = _run_orchestrator_cli("run", "--task-dir", str(task_dir))
+    assert auto_result.returncode == 0
+    checkpoint = json.loads((task_dir / "checkpoint.json").read_text(encoding="utf-8"))
+    assert checkpoint["route"] == "small"
+
+    raised_result = _run_orchestrator_cli("run", "--task-dir", str(task_dir), "--min-route", "medium")
+    assert raised_result.returncode == 1
+    assert "medium route requires plan-ledger.json" in raised_result.stderr
+
+
 def test_cli_supports_recovery_commands(tmp_path: Path) -> None:
     task_dir = _make_task_dir(tmp_path)
 


### PR DESCRIPTION
## Summary
- make clarify-first the canonical ForgeFlow entry path in docs
- keep direct start/run as a fallback operator surface with auto routing and min-route support
- update CLI help text and runtime tests to match the clarified semantics

## Test Plan
- [x] `pytest -q tests/test_runtime_orchestrator.py`
