### PR TITLE
feat: add harness onboarding starter docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,23 @@ This creates adapter-local presets plus a generated team-init note:
 
 The installer refuses global config targets such as `~/.claude`, `~/.codex`, `~/.cursor`, direct `.claude/agents`, direct `.codex/forgeflow`, and direct `.cursor/rules`. Team presets belong to the project, not your global agent config. The installer reads `package.json` and documents only scripts that actually exist.
 
+For first-time project onboarding, add starter docs:
+
+```bash
+python3 scripts/install_agent_presets.py --adapter claude --target /path/to/your-project --profile nextjs --with-starter-docs
+```
+
+This creates missing starter templates without overwriting existing project docs:
+
+```text
+/path/to/your-project/docs/PRD.md
+/path/to/your-project/docs/ARCHITECTURE.md
+/path/to/your-project/docs/ADR.md
+/path/to/your-project/docs/UI_GUIDE.md
+```
+
+`docs/forgeflow-team-init.md` becomes the quick onboarding note: installed presets, created starter docs, active role prompts, review contract, failure handling, package scripts, and the recommended `/forgeflow:clarify` first run. This intentionally does **not** install `stepN.md`, auto-commit, auto-push, or a second runtime. Those patterns are useful demos in other harnesses, but ForgeFlow keeps the canonical path artifact-first.
+
 ### Local runtime install
 
 ```bash

--- a/docs/plans/2026-04-24-harness-onboarding-absorption.md
+++ b/docs/plans/2026-04-24-harness-onboarding-absorption.md
@@ -1,0 +1,152 @@
+# Harness Onboarding Absorption Implementation Plan
+
+> **For Hermes:** Implement directly with strict TDD for behavior changes. Keep this PR to the first absorption slice only.
+
+**Goal:** Absorb the useful onboarding layer from `harness_framework`/OMC without importing their runtime, auto-commit loop, or parallel control plane.
+
+**Architecture:** Extend the existing project-local preset installer so teams can optionally generate ForgeFlow starter docs and get a richer onboarding/prompt-contract note. Starter docs are templates only; canonical workflow remains `brief`/`plan-ledger`/`run-state`/`review-report` based. Hook bundles and monitoring stay out of this first slice.
+
+**Tech Stack:** Python stdlib installer, markdown templates, pytest, existing ForgeFlow validation suite.
+
+---
+
+## Source Review Summary
+
+- `jha0313/harness_framework` provides useful starter docs (`PRD.md`, `ARCHITECTURE.md`, `ADR.md`, `UI_GUIDE.md`) and a simple hook example, but its `stepN.md + scripts/execute.py` runtime uses automatic branch/commit/push behavior that conflicts with ForgeFlow's artifact-first and review-split model.
+- `Yeachan-Heo/oh-my-claudecode` provides strong examples of prompt/role visibility and operations surfaces, but ForgeFlow already has adapter presets, hooks, and canonical artifacts. Absorb visibility, not runtime mass.
+- First slice: starter docs + richer `docs/forgeflow-team-init.md` + README onboarding docs.
+
+## Non-Goals
+
+- Do not add `stepN.md` or `phases/index.json` as canonical artifacts.
+- Do not add auto-commit, auto-push, or headless execution loops.
+- Do not install hooks by default.
+- Do not add a monitoring script in this PR.
+- Do not add external dependencies.
+
+---
+
+### Task 1: Add failing installer tests for starter docs
+
+**Objective:** Prove `--with-starter-docs` creates starter docs and preserves existing docs.
+
+**Files:**
+- Modify: `tests/test_agent_preset_install.py`
+
+**Steps:**
+1. Add a test that runs `scripts/install_agent_presets.py --with-starter-docs` and asserts these files exist:
+   - `docs/PRD.md`
+   - `docs/ARCHITECTURE.md`
+   - `docs/ADR.md`
+   - `docs/UI_GUIDE.md`
+2. Assert contents include ForgeFlow-specific question/template language, not raw `{placeholder}` markers.
+3. Add a test that pre-creates `docs/PRD.md`, runs installer with `--with-starter-docs`, and asserts the original content is unchanged.
+4. Run:
+   ```bash
+   pytest tests/test_agent_preset_install.py::test_installer_can_generate_starter_docs_without_placeholders tests/test_agent_preset_install.py::test_installer_does_not_overwrite_existing_starter_docs -q
+   ```
+   Expected: FAIL because CLI option and template copy logic do not exist yet.
+
+### Task 2: Add failing tests for team-init onboarding sections
+
+**Objective:** Prove generated `forgeflow-team-init.md` acts as onboarding/prompt-contract note, not just install log.
+
+**Files:**
+- Modify: `tests/test_agent_preset_install.py`
+
+**Steps:**
+1. Add assertions after install that `docs/forgeflow-team-init.md` contains:
+   - `## Starter docs`
+   - `## Active role prompts`
+   - `## Review contract`
+   - `## Failure handling`
+   - `## Recommended first run`
+   - `forgeflow-coordinator`
+   - `forgeflow-quality-reviewer`
+2. For `--with-starter-docs`, assert created starter docs are listed.
+3. Run the targeted test and confirm RED.
+
+### Task 3: Create starter doc templates
+
+**Objective:** Add ForgeFlow-native starter docs as source templates.
+
+**Files:**
+- Create: `templates/starter-docs/PRD.md`
+- Create: `templates/starter-docs/ARCHITECTURE.md`
+- Create: `templates/starter-docs/ADR.md`
+- Create: `templates/starter-docs/UI_GUIDE.md`
+
+**Template constraints:**
+- Question-driven, not placeholder-only.
+- Mention ForgeFlow artifacts as downstream consumers where useful.
+- No `{프로젝트명}` style raw placeholders.
+- No canonical runtime replacement language.
+
+### Task 4: Implement installer option and non-overwrite copy
+
+**Objective:** Make installer support optional starter docs generation.
+
+**Files:**
+- Modify: `scripts/install_agent_presets.py`
+
+**Steps:**
+1. Add `STARTER_DOCS_ROOT = ROOT / "templates/starter-docs"`.
+2. Add `copy_starter_docs(target: Path) -> list[Path]` that copies missing templates into `target/docs/` and skips existing files.
+3. Extend `install(..., with_starter_docs: bool = False)` to return created docs.
+4. Add CLI flag `--with-starter-docs`.
+5. Update CLI output to print created starter doc count when enabled.
+6. Run targeted tests from Tasks 1-2 and confirm GREEN.
+
+### Task 5: Enhance team-init note
+
+**Objective:** Include active prompt contracts, review expectations, first-run checklist, and generated starter docs.
+
+**Files:**
+- Modify: `scripts/install_agent_presets.py`
+
+**Steps:**
+1. Extend `write_doc(...)` signature to accept `starter_docs: list[Path]`.
+2. Add sections:
+   - Starter docs
+   - Active role prompts
+   - Review contract
+   - Failure handling
+   - Recommended first run
+3. Keep existing safety boundary and package scripts sections.
+4. Run:
+   ```bash
+   pytest tests/test_agent_preset_install.py -q
+   ```
+
+### Task 6: Document the onboarding path
+
+**Objective:** Make README match the actual installer UX.
+
+**Files:**
+- Modify: `README.md`
+
+**Steps:**
+1. Add a compact section near project-local preset install / repo map describing:
+   ```bash
+   python3 scripts/install_agent_presets.py --adapter claude --target /path/to/project --profile nextjs --with-starter-docs
+   ```
+2. Document that starter docs are skipped when existing files are present.
+3. State explicitly that this does not install `stepN.md`, auto-commit, or auto-push runtime.
+
+### Task 7: Final verification and commit
+
+**Objective:** Prove the slice is complete and safe.
+
+**Commands:**
+```bash
+pytest tests/test_agent_preset_install.py -q
+make validate
+python -m pytest -q
+git diff --check
+```
+
+**Commit:**
+```bash
+git add docs/plans/2026-04-24-harness-onboarding-absorption.md scripts/install_agent_presets.py tests/test_agent_preset_install.py templates/starter-docs README.md
+git commit -m "feat: add harness onboarding starter docs"
+```

--- a/scripts/install_agent_presets.py
+++ b/scripts/install_agent_presets.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SUPPORTED_PROFILES = {"nextjs"}
+STARTER_DOCS_ROOT = ROOT / "templates/starter-docs"
+STARTER_DOC_NAMES = ("PRD.md", "ARCHITECTURE.md", "ADR.md", "UI_GUIDE.md")
 
 
 @dataclass(frozen=True)
@@ -132,6 +134,22 @@ def copy_presets(target: Path, profile: str, spec: AdapterSpec) -> list[Path]:
     return copied
 
 
+def copy_starter_docs(target: Path) -> list[Path]:
+    docs_dir = target / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    created: list[Path] = []
+    for name in STARTER_DOC_NAMES:
+        src = STARTER_DOCS_ROOT / name
+        if not src.exists():
+            raise FileNotFoundError(f"Missing starter doc template: {src}")
+        dst = docs_dir / name
+        if dst.exists():
+            continue
+        shutil.copyfile(src, dst)
+        created.append(dst)
+    return created
+
+
 def verification_lines(scripts: dict[str, str]) -> list[str]:
     preferred = ["dev", "build", "lint", "test"]
     lines = []
@@ -143,10 +161,21 @@ def verification_lines(scripts: dict[str, str]) -> list[str]:
     return lines
 
 
-def write_doc(target: Path, profile: str, adapter: str, copied: list[Path], scripts: dict[str, str], spec: AdapterSpec) -> Path:
+def write_doc(
+    target: Path,
+    profile: str,
+    adapter: str,
+    copied: list[Path],
+    scripts: dict[str, str],
+    spec: AdapterSpec,
+    starter_docs: list[Path],
+) -> Path:
     doc = target / "docs" / "forgeflow-team-init.md"
     doc.parent.mkdir(parents=True, exist_ok=True)
     preset_lines = [f"- `{path.relative_to(target)}`" for path in copied]
+    starter_lines = [f"- `{path.relative_to(target)}`" for path in starter_docs]
+    if not starter_lines:
+        starter_lines = ["- No starter docs were created in this run. Existing project docs are preserved."]
     content = "\n".join(
         [
             f"# {spec.title}",
@@ -157,6 +186,30 @@ def write_doc(target: Path, profile: str, adapter: str, copied: list[Path], scri
             "## Installed project-local ForgeFlow presets",
             "",
             *preset_lines,
+            "",
+            "## Starter docs",
+            "",
+            *starter_lines,
+            "",
+            "Use these as project-local inputs for ForgeFlow planning. They guide product, architecture, decisions, and UI expectations without replacing canonical artifacts like `brief.json`, `plan-ledger.json`, `run-state.json`, or `review-report.json`.",
+            "",
+            "## Active role prompts",
+            "",
+            "- `forgeflow-coordinator` — chooses stage, route, missing artifacts, and next handoff.",
+            "- `forgeflow-nextjs-worker` — performs scoped implementation and records evidence.",
+            "- `forgeflow-quality-reviewer` — performs independent quality review before completion claims.",
+            "",
+            "## Review contract",
+            "",
+            "- Do not claim done without fresh verification evidence.",
+            "- Require independent quality review for non-trivial implementation work.",
+            "- Reject changes that drift from PRD, Architecture, ADR, or ForgeFlow stage artifacts.",
+            "",
+            "## Failure handling",
+            "",
+            "- If verification fails, record the failing command and fix the smallest cause first.",
+            "- If scope changes, return to `/forgeflow:clarify` instead of silently expanding the task.",
+            "- If review rejects the change, update the plan/evidence before another completion claim.",
             "",
             "## Safety boundary",
             "",
@@ -172,13 +225,20 @@ def write_doc(target: Path, profile: str, adapter: str, copied: list[Path], scri
             "2. Use `forgeflow-nextjs-worker.md` for scoped Next.js implementation tasks.",
             "3. Use `forgeflow-quality-reviewer.md` before declaring the task complete.",
             "",
+            "## Recommended first run",
+            "",
+            "1. Fill or skim `docs/PRD.md`, `docs/ARCHITECTURE.md`, `docs/ADR.md`, and `docs/UI_GUIDE.md` when they exist.",
+            "2. Start with `/forgeflow:clarify <task>`.",
+            "3. Let the agent produce the plan and then run within the approved scope.",
+            "4. Run the available verification commands below and attach evidence to the final report.",
+            "",
         ]
     )
     doc.write_text(content, encoding="utf-8")
     return doc
 
 
-def install(target_arg: str, adapter: str, profile: str) -> tuple[Path, list[Path], Path]:
+def install(target_arg: str, adapter: str, profile: str, *, with_starter_docs: bool = False) -> tuple[Path, list[Path], Path, list[Path]]:
     if adapter not in ADAPTERS:
         raise ValueError(f"Unsupported adapter: {adapter}")
     spec = ADAPTERS[adapter]
@@ -186,8 +246,9 @@ def install(target_arg: str, adapter: str, profile: str) -> tuple[Path, list[Pat
     target.mkdir(parents=True, exist_ok=True)
     scripts = load_package_scripts(target)
     copied = copy_presets(target, profile, spec)
-    doc = write_doc(target, profile, adapter, copied, scripts, spec)
-    return target, copied, doc
+    starter_docs = copy_starter_docs(target) if with_starter_docs else []
+    doc = write_doc(target, profile, adapter, copied, scripts, spec, starter_docs)
+    return target, copied, doc, starter_docs
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -195,14 +256,26 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--adapter", choices=sorted(ADAPTERS), required=True)
     parser.add_argument("--target", required=True, help="Project root to install into")
     parser.add_argument("--profile", choices=sorted(SUPPORTED_PROFILES), default="nextjs")
+    parser.add_argument(
+        "--with-starter-docs",
+        action="store_true",
+        help="Create missing docs/PRD.md, ARCHITECTURE.md, ADR.md, and UI_GUIDE.md starter templates",
+    )
     args = parser.parse_args(argv)
 
     try:
-        target, copied, doc = install(args.target, args.adapter, args.profile)
+        target, copied, doc, starter_docs = install(
+            args.target,
+            args.adapter,
+            args.profile,
+            with_starter_docs=args.with_starter_docs,
+        )
     except Exception as exc:  # noqa: BLE001 - CLI reports concise failure
         return die(str(exc))
 
     print(f"Installed {len(copied)} {args.adapter} presets into {target / ADAPTERS[args.adapter].install_subdir}")
+    if args.with_starter_docs:
+        print(f"Created {len(starter_docs)} starter docs under {target / 'docs'}")
     print(f"Wrote {doc}")
     return 0
 

--- a/scripts/install_claude_agent_presets.py
+++ b/scripts/install_claude_agent_presets.py
@@ -25,7 +25,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     try:
-        target, copied, doc = install(args.target, "claude", args.profile)
+        target, copied, doc, _starter_docs = install(args.target, "claude", args.profile)
     except Exception as exc:  # noqa: BLE001 - CLI reports concise failure
         return die(str(exc))
 

--- a/templates/starter-docs/ADR.md
+++ b/templates/starter-docs/ADR.md
@@ -1,0 +1,33 @@
+# ADR Log
+
+Record architecture decisions that ForgeFlow workers and reviewers must preserve. Add a new entry for decisions that affect interfaces, dependencies, persistence, security, or deployment.
+
+## ADR template
+
+### ADR-0001: Decision title
+
+**Status:** proposed | accepted | superseded
+
+**Context**
+
+What problem or tradeoff forced this decision?
+
+**Decision**
+
+What are we choosing?
+
+**Consequences**
+
+- Positive:
+- Negative:
+- Follow-up checks:
+
+**ForgeFlow review notes**
+
+What should a reviewer reject if future changes violate this decision?
+
+---
+
+## Active decisions
+
+Add project decisions below this line.

--- a/templates/starter-docs/ARCHITECTURE.md
+++ b/templates/starter-docs/ARCHITECTURE.md
@@ -1,0 +1,49 @@
+# Architecture
+
+This starter doc records the project structure ForgeFlow agents must respect. It is guidance for planning and review, not a replacement for ForgeFlow canonical artifacts.
+
+## System overview
+
+- Runtime/application type:
+- Main entry points:
+- External services:
+- Data stores:
+
+## Directory map
+
+```text
+.
+├── src/ or app/
+├── tests/
+└── docs/
+```
+
+Explain the important directories and what must not be placed there.
+
+## Boundaries
+
+- UI boundary:
+- API/server boundary:
+- Data access boundary:
+- Background jobs or schedulers:
+
+## Non-negotiable rules
+
+Write rules that reviewers can verify.
+
+- 
+- 
+- 
+
+## Dependency policy
+
+- Existing libraries to prefer:
+- New dependency approval rule:
+- Generated files or build outputs:
+
+## Verification architecture
+
+- Unit test command:
+- Integration/e2e command:
+- Lint/type/build command:
+- Files or artifacts reviewers should inspect:

--- a/templates/starter-docs/PRD.md
+++ b/templates/starter-docs/PRD.md
@@ -1,0 +1,52 @@
+# PRD
+
+This starter doc helps ForgeFlow turn product intent into `brief.json`, `plan-ledger.json`, and reviewable acceptance criteria. Fill it before large work; keep small fixes lightweight.
+
+## Problem
+
+- Who has the problem?
+- What painful workflow or missing capability are we fixing?
+- What happens if we do nothing?
+
+## Users and jobs
+
+- Primary user:
+- Secondary users:
+- Job-to-be-done:
+
+## Scope
+
+### In scope
+
+- 
+
+### Out of scope
+
+- 
+
+## User workflows
+
+1. 
+2. 
+3. 
+
+## Acceptance criteria
+
+Use concrete, testable statements. Good criteria should map to commands, screenshots, API responses, or artifact checks.
+
+- [ ] 
+- [ ] 
+- [ ] 
+
+## Risks and constraints
+
+- Product risk:
+- Technical risk:
+- Data/source-of-truth constraint:
+- Manual approval or external side effect:
+
+## Verification signals
+
+- Build/test command:
+- Manual QA path:
+- Review evidence expected in ForgeFlow artifacts:

--- a/templates/starter-docs/UI_GUIDE.md
+++ b/templates/starter-docs/UI_GUIDE.md
@@ -1,0 +1,36 @@
+# UI Guide
+
+Use this only when the project has a user interface. Keep it short enough that ForgeFlow agents can actually follow it.
+
+## Product feel
+
+- Reference product or design system:
+- Tone:
+- Density:
+- Accessibility baseline:
+
+## Layout rules
+
+- Page structure:
+- Navigation:
+- Empty/loading/error states:
+- Responsive behavior:
+
+## Components
+
+List reusable components and where they live.
+
+- 
+
+## Copy and localization
+
+- Language style:
+- Terms to use:
+- Terms to avoid:
+
+## Visual QA checklist
+
+- [ ] Important actions are visible without hunting.
+- [ ] Error states explain recovery.
+- [ ] Keyboard and screen-reader basics are not broken.
+- [ ] Screenshots or manual QA notes are attached when UI changes are non-trivial.

--- a/tests/test_agent_preset_install.py
+++ b/tests/test_agent_preset_install.py
@@ -126,3 +126,83 @@ def test_legacy_claude_installer_wrapper_still_works(tmp_path):
     assert result.returncode == 0, result.stderr
     assert (target / ".claude/agents/forgeflow-coordinator.md").exists()
     assert "Adapter: `claude`" in (target / "docs/forgeflow-team-init.md").read_text(encoding="utf-8")
+
+
+
+def test_installer_can_generate_starter_docs_without_placeholders(tmp_path):
+    target = tmp_path / "app"
+    write_package(target, {"dev": "next dev", "build": "next build", "lint": "eslint", "test": "vitest"})
+
+    result = run_installer(
+        GENERIC_INSTALLER,
+        target,
+        "--adapter",
+        "claude",
+        "--profile",
+        "nextjs",
+        "--with-starter-docs",
+    )
+
+    assert result.returncode == 0, result.stderr
+    for name in ["PRD.md", "ARCHITECTURE.md", "ADR.md", "UI_GUIDE.md"]:
+        doc = target / "docs" / name
+        assert doc.exists(), name
+        text = doc.read_text(encoding="utf-8")
+        assert "ForgeFlow" in text
+        assert "{{" not in text
+        assert "}}" not in text
+        assert "{프로젝트명}" not in text
+
+    init = (target / "docs/forgeflow-team-init.md").read_text(encoding="utf-8")
+    assert "## Starter docs" in init
+    assert "docs/PRD.md" in init
+    assert "docs/ARCHITECTURE.md" in init
+
+
+def test_installer_does_not_overwrite_existing_starter_docs(tmp_path):
+    target = tmp_path / "app"
+    write_package(target, {"build": "next build"})
+    existing = target / "docs" / "PRD.md"
+    existing.parent.mkdir(parents=True)
+    existing.write_text("# Existing product doc\nDo not overwrite this.", encoding="utf-8")
+
+    result = run_installer(
+        GENERIC_INSTALLER,
+        target,
+        "--adapter",
+        "codex",
+        "--profile",
+        "nextjs",
+        "--with-starter-docs",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert existing.read_text(encoding="utf-8") == "# Existing product doc\nDo not overwrite this."
+    assert (target / "docs/ARCHITECTURE.md").exists()
+
+
+def test_team_init_document_exposes_prompt_and_review_contract(tmp_path):
+    target = tmp_path / "app"
+    write_package(target, {"build": "next build", "lint": "eslint", "test": "vitest run"})
+
+    result = run_installer(
+        GENERIC_INSTALLER,
+        target,
+        "--adapter",
+        "cursor",
+        "--profile",
+        "nextjs",
+        "--with-starter-docs",
+    )
+
+    assert result.returncode == 0, result.stderr
+    text = (target / "docs/forgeflow-team-init.md").read_text(encoding="utf-8")
+    assert "## Active role prompts" in text
+    assert "forgeflow-coordinator" in text
+    assert "forgeflow-nextjs-worker" in text
+    assert "forgeflow-quality-reviewer" in text
+    assert "## Review contract" in text
+    assert "independent quality review" in text
+    assert "## Failure handling" in text
+    assert "## Recommended first run" in text
+    assert "/forgeflow:clarify" in text


### PR DESCRIPTION
## Summary
- Add a harness onboarding absorption plan under `docs/plans/`
- Add `--with-starter-docs` to project-local preset installer
- Create ForgeFlow-native starter templates for PRD, Architecture, ADR, and UI Guide
- Expand generated `docs/forgeflow-team-init.md` into an onboarding/prompt-contract note
- Document the onboarding path and explicitly reject stepN/auto-commit runtime absorption

## Test Plan
- `python -m py_compile scripts/install_agent_presets.py scripts/install_claude_agent_presets.py`
- `pytest tests/test_agent_preset_install.py -q`
- `make validate`
- `python -m pytest -q`
- `git diff --check`

## Source absorption boundary
This absorbs the useful starter-doc/onboarding layer from the reviewed harness sources, but does not import their runtime model, auto-commit loop, auto-push behavior, default hooks, or a second canonical workflow.
