### PR TITLE
feat: add opt-in claude safety bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ This creates missing starter templates without overwriting existing project docs
 
 `docs/forgeflow-team-init.md` becomes the quick onboarding note: installed presets, created starter docs, active role prompts, review contract, failure handling, package scripts, and the recommended `/forgeflow:clarify` first run. This intentionally does **not** install `stepN.md`, auto-commit, auto-push, or a second runtime. Those patterns are useful demos in other harnesses, but ForgeFlow keeps the canonical path artifact-first.
 
+Claude projects can opt into a tiny project-local safety bundle:
+
+```bash
+python3 scripts/install_agent_presets.py --adapter claude --target /path/to/your-project --profile nextjs --hook-bundles basic-safety
+```
+
+`basic-safety` installs `.claude/settings.json` and `.claude/hooks/forgeflow/basic_safety_guard.py` in the target project. It blocks obviously destructive Bash commands such as `rm -rf`, `git reset --hard`, `git push --force`, and `DROP TABLE`. This is a guardrail, not a sandbox. It is Claude-only for now, opt-in only, and the installer refuses to overwrite an existing `.claude/settings.json`.
+
 ### Local runtime install
 
 ```bash

--- a/adapters/targets/claude/hook-bundles/basic-safety/basic_safety_guard.py
+++ b/adapters/targets/claude/hook-bundles/basic-safety/basic_safety_guard.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""ForgeFlow project-local basic safety guard for Claude Code Bash calls."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+DANGEROUS_PATTERNS = [
+    (re.compile(r"\brm\s+[^\n;]*-[^\n;]*[rR][^\n;]*[fF]|\brm\s+[^\n;]*-[^\n;]*[fF][^\n;]*[rR]"), "recursive force removal"),
+    (re.compile(r"\bgit\s+reset\s+--hard\b"), "hard git reset"),
+    (re.compile(r"\bgit\s+push\b[^\n;]*\s--force(?:-with-lease)?\b"), "force push"),
+    (re.compile(r"\bDROP\s+TABLE\b", re.IGNORECASE), "destructive SQL"),
+]
+
+
+def load_payload() -> dict:
+    try:
+        return json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return {}
+
+
+def main() -> int:
+    payload = load_payload()
+    if payload.get("tool_name") != "Bash":
+        return 0
+    tool_input = payload.get("tool_input") or {}
+    command = str(tool_input.get("command") or "")
+    for pattern, reason in DANGEROUS_PATTERNS:
+        if pattern.search(command):
+            print(
+                "FORGEFLOW BASIC SAFETY: blocked Bash command "
+                f"because it looks like {reason}. This project-local hook is a guardrail, "
+                "not a complete sandbox. If this is intentional, perform the action manually "
+                "after reviewing scope and dirty working tree state.",
+                file=sys.stderr,
+            )
+            return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/adapters/targets/claude/hook-bundles/basic-safety/settings.json
+++ b/adapters/targets/claude/hook-bundles/basic-safety/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/forgeflow/basic_safety_guard.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/plans/2026-04-24-harness-safety-bundles.md
+++ b/docs/plans/2026-04-24-harness-safety-bundles.md
@@ -1,0 +1,123 @@
+# Harness Safety Bundles Implementation Plan
+
+> **For Hermes:** Implement this slice with strict TDD. Keep it project-local opt-in; do not install hooks by default.
+
+**Goal:** Add a minimal project-local safety bundle installer path that exposes ForgeFlow's guard intent for Claude projects without importing `harness_framework`'s global Stop-hook runtime or auto-commit loop.
+
+**Architecture:** Extend `scripts/install_agent_presets.py` with `--hook-bundles`. For this first hook slice, support Claude only and install a static project-local `.claude/settings.json` plus hook scripts under `.claude/hooks/forgeflow/`. Codex/Cursor should fail clearly for hook bundles instead of pretending equivalent runtime hooks exist. Hooks are small Python stdlib scripts receiving Claude Code stdin JSON.
+
+**Tech Stack:** Python stdlib, Claude Code hook JSON stdin contract, pytest.
+
+---
+
+## Non-Goals
+
+- Do not enable hooks by default.
+- Do not run full build/test on every Stop.
+- Do not add auto-commit, auto-push, or `stepN.md` runtime.
+- Do not edit global `~/.claude/settings.json`.
+- Do not claim regex command guards are a complete security model.
+
+## Bundle scope for PR2
+
+Support one bundle first:
+
+```text
+basic-safety
+```
+
+It installs:
+
+```text
+.claude/hooks/forgeflow/basic_safety_guard.py
+.claude/settings.json
+```
+
+Behavior:
+- PreToolUse/Bash hook blocks obviously destructive commands: `rm -rf`, `git reset --hard`, `git push --force`, `DROP TABLE`.
+- Allows normal non-destructive commands.
+- Emits a concise block message and exits 2 when blocking.
+
+---
+
+### Task 1: Add failing installer tests
+
+**Files:**
+- Modify: `tests/test_agent_preset_install.py`
+
+**Test cases:**
+1. `--hook-bundles basic-safety` with `--adapter claude` creates:
+   - `.claude/hooks/forgeflow/basic_safety_guard.py`
+   - `.claude/settings.json`
+2. Generated `docs/forgeflow-team-init.md` lists `basic-safety` under a safety bundle section.
+3. `--hook-bundles basic-safety` with `--adapter codex` fails with a clear `Claude adapter only` message.
+4. Running without `--hook-bundles` creates no `.claude/settings.json`.
+
+**RED command:**
+```bash
+pytest tests/test_agent_preset_install.py::test_claude_installer_can_install_basic_safety_hook_bundle tests/test_agent_preset_install.py::test_hook_bundles_are_claude_only tests/test_agent_preset_install.py::test_installer_does_not_install_hooks_by_default -q
+```
+
+### Task 2: Add failing hook behavior tests
+
+**Files:**
+- Create/modify: `tests/test_claude_safety_bundle_hooks.py`
+
+**Test cases:**
+1. Run `basic_safety_guard.py` with stdin:
+   ```json
+   {"tool_name":"Bash","tool_input":{"command":"rm -rf node_modules"}}
+   ```
+   Expected: exit 2 and stderr contains `FORGEFLOW BASIC SAFETY`.
+2. Run with `npm run test` and expect exit 0.
+3. Run with non-Bash payload and expect exit 0.
+
+**RED command:**
+```bash
+pytest tests/test_claude_safety_bundle_hooks.py -q
+```
+
+### Task 3: Implement hook template and settings writer
+
+**Files:**
+- Create: `adapters/targets/claude/hook-bundles/basic-safety/basic_safety_guard.py`
+- Create: `adapters/targets/claude/hook-bundles/basic-safety/settings.json`
+- Modify: `scripts/install_agent_presets.py`
+
+**Implementation:**
+- Add `SUPPORTED_HOOK_BUNDLES = {"basic-safety"}`.
+- Add CLI `--hook-bundles` as comma-separated list.
+- Reject hook bundles for adapters other than Claude.
+- Copy bundle files into `.claude/hooks/forgeflow/` and `.claude/settings.json`.
+- Do not overwrite existing `.claude/settings.json`; fail clearly if it already exists.
+
+### Task 4: Update onboarding note and docs
+
+**Files:**
+- Modify: `scripts/install_agent_presets.py`
+- Modify: `README.md`
+
+**Implementation:**
+- Add `## Installed hook/safety bundles` to `forgeflow-team-init.md`.
+- README documents:
+  ```bash
+  python3 scripts/install_agent_presets.py --adapter claude --target /path/to/project --profile nextjs --hook-bundles basic-safety
+  ```
+- README states hooks are opt-in, project-local, and not a complete security sandbox.
+
+### Task 5: Verify and commit
+
+**Commands:**
+```bash
+python -m py_compile scripts/install_agent_presets.py adapters/targets/claude/hook-bundles/basic-safety/basic_safety_guard.py
+pytest tests/test_agent_preset_install.py tests/test_claude_safety_bundle_hooks.py -q
+make validate
+python -m pytest -q
+git diff --check
+```
+
+**Commit:**
+```bash
+git add docs/plans/2026-04-24-harness-safety-bundles.md scripts/install_agent_presets.py adapters/targets/claude/hook-bundles tests/test_agent_preset_install.py tests/test_claude_safety_bundle_hooks.py README.md
+git commit -m "feat: add opt-in claude safety bundle"
+```

--- a/scripts/install_agent_presets.py
+++ b/scripts/install_agent_presets.py
@@ -14,6 +14,8 @@ ROOT = Path(__file__).resolve().parents[1]
 SUPPORTED_PROFILES = {"nextjs"}
 STARTER_DOCS_ROOT = ROOT / "templates/starter-docs"
 STARTER_DOC_NAMES = ("PRD.md", "ARCHITECTURE.md", "ADR.md", "UI_GUIDE.md")
+SUPPORTED_HOOK_BUNDLES = {"basic-safety"}
+HOOK_BUNDLE_ROOT = ROOT / "adapters/targets/claude/hook-bundles"
 
 
 @dataclass(frozen=True)
@@ -150,6 +152,42 @@ def copy_starter_docs(target: Path) -> list[Path]:
     return created
 
 
+def parse_hook_bundles(raw: str | None) -> list[str]:
+    if not raw:
+        return []
+    bundles = [item.strip() for item in raw.split(",") if item.strip()]
+    unknown = sorted(set(bundles) - SUPPORTED_HOOK_BUNDLES)
+    if unknown:
+        raise ValueError(f"Unsupported hook bundle(s): {', '.join(unknown)}")
+    return bundles
+
+
+def install_hook_bundles(target: Path, adapter: str, bundles: list[str]) -> list[str]:
+    if not bundles:
+        return []
+    if adapter != "claude":
+        raise ValueError("Hook bundles are Claude adapter only for now; Codex and Cursor receive safety intent through presets/rules.")
+
+    installed: list[str] = []
+    for bundle in bundles:
+        if bundle == "basic-safety":
+            src_dir = HOOK_BUNDLE_ROOT / bundle
+            hook_src = src_dir / "basic_safety_guard.py"
+            settings_src = src_dir / "settings.json"
+            if not hook_src.exists() or not settings_src.exists():
+                raise FileNotFoundError(f"Missing hook bundle template: {src_dir}")
+            hook_dst_dir = target / ".claude" / "hooks" / "forgeflow"
+            hook_dst_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(hook_src, hook_dst_dir / hook_src.name)
+            settings_dst = target / ".claude" / "settings.json"
+            if settings_dst.exists():
+                raise ValueError("Refusing to overwrite existing .claude/settings.json; install hook bundles manually or remove the file first.")
+            settings_dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(settings_src, settings_dst)
+            installed.append(bundle)
+    return installed
+
+
 def verification_lines(scripts: dict[str, str]) -> list[str]:
     preferred = ["dev", "build", "lint", "test"]
     lines = []
@@ -169,6 +207,7 @@ def write_doc(
     scripts: dict[str, str],
     spec: AdapterSpec,
     starter_docs: list[Path],
+    hook_bundles: list[str],
 ) -> Path:
     doc = target / "docs" / "forgeflow-team-init.md"
     doc.parent.mkdir(parents=True, exist_ok=True)
@@ -176,6 +215,9 @@ def write_doc(
     starter_lines = [f"- `{path.relative_to(target)}`" for path in starter_docs]
     if not starter_lines:
         starter_lines = ["- No starter docs were created in this run. Existing project docs are preserved."]
+    hook_lines = [f"- `{bundle}` — project-local opt-in Claude safety bundle." for bundle in hook_bundles]
+    if not hook_lines:
+        hook_lines = ["- No hook/safety bundles installed. Hooks are opt-in and project-local only."]
     content = "\n".join(
         [
             f"# {spec.title}",
@@ -211,6 +253,12 @@ def write_doc(
             "- If scope changes, return to `/forgeflow:clarify` instead of silently expanding the task.",
             "- If review rejects the change, update the plan/evidence before another completion claim.",
             "",
+            "## Installed hook/safety bundles",
+            "",
+            *hook_lines,
+            "",
+            "These guardrails are convenience checks, not a complete sandbox or permission model.",
+            "",
             "## Safety boundary",
             "",
             f"These presets are installed under this project only. Do not create or update `{Path.home() / spec.global_config_names[0]}` for project team setup.",
@@ -238,17 +286,26 @@ def write_doc(
     return doc
 
 
-def install(target_arg: str, adapter: str, profile: str, *, with_starter_docs: bool = False) -> tuple[Path, list[Path], Path, list[Path]]:
+def install(
+    target_arg: str,
+    adapter: str,
+    profile: str,
+    *,
+    with_starter_docs: bool = False,
+    hook_bundles: list[str] | None = None,
+) -> tuple[Path, list[Path], Path, list[Path], list[str]]:
     if adapter not in ADAPTERS:
         raise ValueError(f"Unsupported adapter: {adapter}")
     spec = ADAPTERS[adapter]
     target = safe_target_root(target_arg, spec)
     target.mkdir(parents=True, exist_ok=True)
     scripts = load_package_scripts(target)
+    bundles = hook_bundles or []
     copied = copy_presets(target, profile, spec)
     starter_docs = copy_starter_docs(target) if with_starter_docs else []
-    doc = write_doc(target, profile, adapter, copied, scripts, spec, starter_docs)
-    return target, copied, doc, starter_docs
+    installed_bundles = install_hook_bundles(target, adapter, bundles)
+    doc = write_doc(target, profile, adapter, copied, scripts, spec, starter_docs, installed_bundles)
+    return target, copied, doc, starter_docs, installed_bundles
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -261,14 +318,21 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Create missing docs/PRD.md, ARCHITECTURE.md, ADR.md, and UI_GUIDE.md starter templates",
     )
+    parser.add_argument(
+        "--hook-bundles",
+        default="",
+        help="Comma-separated project-local hook bundles to install. Currently supports Claude-only: basic-safety",
+    )
     args = parser.parse_args(argv)
 
     try:
-        target, copied, doc, starter_docs = install(
+        bundles = parse_hook_bundles(args.hook_bundles)
+        target, copied, doc, starter_docs, installed_bundles = install(
             args.target,
             args.adapter,
             args.profile,
             with_starter_docs=args.with_starter_docs,
+            hook_bundles=bundles,
         )
     except Exception as exc:  # noqa: BLE001 - CLI reports concise failure
         return die(str(exc))
@@ -276,6 +340,8 @@ def main(argv: list[str] | None = None) -> int:
     print(f"Installed {len(copied)} {args.adapter} presets into {target / ADAPTERS[args.adapter].install_subdir}")
     if args.with_starter_docs:
         print(f"Created {len(starter_docs)} starter docs under {target / 'docs'}")
+    if installed_bundles:
+        print(f"Installed hook bundles: {', '.join(installed_bundles)}")
     print(f"Wrote {doc}")
     return 0
 

--- a/scripts/install_claude_agent_presets.py
+++ b/scripts/install_claude_agent_presets.py
@@ -25,7 +25,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     try:
-        target, copied, doc, _starter_docs = install(args.target, "claude", args.profile)
+        target, copied, doc, _starter_docs, _hook_bundles = install(args.target, "claude", args.profile)
     except Exception as exc:  # noqa: BLE001 - CLI reports concise failure
         return die(str(exc))
 

--- a/tests/test_agent_preset_install.py
+++ b/tests/test_agent_preset_install.py
@@ -206,3 +206,62 @@ def test_team_init_document_exposes_prompt_and_review_contract(tmp_path):
     assert "## Failure handling" in text
     assert "## Recommended first run" in text
     assert "/forgeflow:clarify" in text
+
+
+
+def test_claude_installer_can_install_basic_safety_hook_bundle(tmp_path):
+    target = tmp_path / "app"
+    write_package(target, {"build": "next build"})
+
+    result = run_installer(
+        GENERIC_INSTALLER,
+        target,
+        "--adapter",
+        "claude",
+        "--profile",
+        "nextjs",
+        "--hook-bundles",
+        "basic-safety",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (target / ".claude/hooks/forgeflow/basic_safety_guard.py").exists()
+    settings = json.loads((target / ".claude/settings.json").read_text(encoding="utf-8"))
+    pretool = settings["hooks"]["PreToolUse"][0]
+    assert pretool["matcher"] == "Bash"
+    assert "basic_safety_guard.py" in pretool["hooks"][0]["command"]
+
+    init = (target / "docs/forgeflow-team-init.md").read_text(encoding="utf-8")
+    assert "## Installed hook/safety bundles" in init
+    assert "basic-safety" in init
+    assert "project-local opt-in" in init
+
+
+def test_hook_bundles_are_claude_only(tmp_path):
+    target = tmp_path / "app"
+    write_package(target, {"build": "next build"})
+
+    result = run_installer(
+        GENERIC_INSTALLER,
+        target,
+        "--adapter",
+        "codex",
+        "--profile",
+        "nextjs",
+        "--hook-bundles",
+        "basic-safety",
+    )
+
+    assert result.returncode != 0
+    assert "Claude adapter only" in result.stderr
+
+
+def test_installer_does_not_install_hooks_by_default(tmp_path):
+    target = tmp_path / "app"
+    write_package(target, {"build": "next build"})
+
+    result = run_installer(GENERIC_INSTALLER, target, "--adapter", "claude", "--profile", "nextjs")
+
+    assert result.returncode == 0, result.stderr
+    assert not (target / ".claude/settings.json").exists()
+    assert not (target / ".claude/hooks/forgeflow/basic_safety_guard.py").exists()

--- a/tests/test_claude_safety_bundle_hooks.py
+++ b/tests/test_claude_safety_bundle_hooks.py
@@ -1,0 +1,37 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOK = ROOT / "adapters" / "targets" / "claude" / "hook-bundles" / "basic-safety" / "basic_safety_guard.py"
+
+
+def run_hook(payload: dict) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_basic_safety_hook_blocks_destructive_bash_command():
+    result = run_hook({"tool_name": "Bash", "tool_input": {"command": "rm -rf node_modules"}})
+
+    assert result.returncode == 2
+    assert "FORGEFLOW BASIC SAFETY" in result.stderr
+
+
+def test_basic_safety_hook_allows_normal_bash_command():
+    result = run_hook({"tool_name": "Bash", "tool_input": {"command": "npm run test"}})
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+
+def test_basic_safety_hook_ignores_non_bash_tools():
+    result = run_hook({"tool_name": "Read", "tool_input": {"file_path": "README.md"}})
+
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary
- Merge PR #31 first, then add the next absorption slice: opt-in Claude safety bundles
- Add a task plan for harness safety bundles
- Add `--hook-bundles basic-safety` to `scripts/install_agent_presets.py`
- Install project-local `.claude/settings.json` and `.claude/hooks/forgeflow/basic_safety_guard.py` only when explicitly requested
- Document that this is a guardrail, not a sandbox, and Claude-only for now

## Test Plan
- `python -m py_compile scripts/install_agent_presets.py scripts/install_claude_agent_presets.py adapters/targets/claude/hook-bundles/basic-safety/basic_safety_guard.py`
- `pytest tests/test_agent_preset_install.py tests/test_claude_safety_bundle_hooks.py -q`
- `make validate`
- `python -m pytest -q`
- `git diff --check`

## Safety boundary
This does not install hooks by default, does not touch global `~/.claude/settings.json`, does not overwrite existing project `.claude/settings.json`, and does not add auto-commit/auto-push/runtime loops.
