### PR TITLE
feat: add forgeflow monitor summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,17 @@ python3 scripts/install_agent_presets.py --adapter claude --target /path/to/your
 
 `basic-safety` installs `.claude/settings.json` and `.claude/hooks/forgeflow/basic_safety_guard.py` in the target project. It blocks obviously destructive Bash commands such as `rm -rf`, `git reset --hard`, `git push --force`, and `DROP TABLE`. This is a guardrail, not a sandbox. It is Claude-only for now, opt-in only, and the installer refuses to overwrite an existing `.claude/settings.json`.
 
+### Local monitoring summary
+
+ForgeFlow task artifacts are local files, so the first observability layer is just a read-only local summary:
+
+```bash
+python3 scripts/forgeflow_monitor.py --tasks .forgeflow/tasks --recent 10 --format md
+python3 scripts/forgeflow_monitor.py --tasks .forgeflow/tasks --recent 10 --format json
+```
+
+It reads `run-state.json`, `review-report.json`, `eval-record.json`, and `decision-log.json` when present, then reports task counts, blocked/error counts, review rejects, artifact parse errors, and repeated failure messages. It does not mutate artifacts, call an LLM, run tests, send notifications, or start a dashboard. Good. Dashboards reproduce when fed after midnight.
+
 ### Local runtime install
 
 ```bash

--- a/docs/plans/2026-04-24-forgeflow-monitor-summary.md
+++ b/docs/plans/2026-04-24-forgeflow-monitor-summary.md
@@ -1,0 +1,134 @@
+# ForgeFlow Monitor Summary Implementation Plan
+
+> **For Hermes:** Implement directly with strict TDD. Keep this feature read-only, local-only, and dependency-free.
+
+**Goal:** Add a lightweight CLI that summarizes recent ForgeFlow task artifacts so operators can see completion, blocking, review rejection, and repeated failure patterns without opening every JSON file by hand.
+
+**Architecture:** `scripts/forgeflow_monitor.py` scans a local `.forgeflow/tasks` directory, reads known artifact files when present, tolerates missing/malformed artifacts, and emits either Markdown or JSON. It does not mutate tasks, call LLMs, run verification commands, or send notifications.
+
+**Tech Stack:** Python stdlib (`argparse`, `json`, `pathlib`, `collections`), pytest, existing repo validation.
+
+---
+
+## Non-Goals
+
+- No external DB, SaaS dashboard, cron, Telegram/Slack alerts, or web UI.
+- No LLM-generated recommendations.
+- No artifact mutation.
+- No schema migration.
+- No automatic task fixing.
+
+## Data sources
+
+For each task directory under `.forgeflow/tasks/*`, read when present:
+
+```text
+run-state.json
+review-report.json
+eval-record.json
+decision-log.json
+```
+
+Minimum useful fields:
+- task id: directory name, `task_id`, or `id`
+- route/current stage/status from `run-state.json`
+- review approved/rejected status and findings from `review-report.json`
+- eval status/score when present
+- decision or blocked/error messages when present
+
+---
+
+### Task 1: Add failing tests for JSON summary
+
+**Files:**
+- Create: `tests/test_forgeflow_monitor.py`
+
+**Test behavior:**
+1. Create three fake tasks under `tmp_path/.forgeflow/tasks`:
+   - completed task with approved review
+   - blocked task with `blocked_reason`
+   - rejected task with `review-report.json` containing findings
+2. Run:
+   ```bash
+   python3 scripts/forgeflow_monitor.py --tasks <tmp> --format json --recent 10
+   ```
+3. Assert JSON includes:
+   - `summary.total_tasks == 3`
+   - `summary.completed == 1`
+   - `summary.blocked == 1`
+   - `summary.review_rejected == 1`
+   - top failure pattern includes the blocked/review finding text
+
+**RED command:**
+```bash
+pytest tests/test_forgeflow_monitor.py::test_monitor_json_summarizes_task_health -q
+```
+
+### Task 2: Add failing tests for Markdown and graceful fallback
+
+**Files:**
+- Modify: `tests/test_forgeflow_monitor.py`
+
+**Test behavior:**
+1. Markdown output contains:
+   - `# ForgeFlow monitor summary`
+   - `Total tasks: 3`
+   - `Review rejected: 1`
+   - task table rows
+2. Missing artifacts do not crash; a task directory with no JSON still appears as `unknown`.
+3. Malformed JSON is counted in `artifact_errors` but does not crash.
+
+**RED command:**
+```bash
+pytest tests/test_forgeflow_monitor.py -q
+```
+
+### Task 3: Implement monitor CLI
+
+**Files:**
+- Create: `scripts/forgeflow_monitor.py`
+
+**Implementation outline:**
+- `load_json(path) -> tuple[dict | None, str | None]`
+- `discover_tasks(tasks_root, recent) -> list[Path]`, newest by mtime descending
+- `summarize_task(task_dir) -> dict`
+- `build_summary(tasks) -> dict`
+- `render_markdown(report) -> str`
+- CLI args:
+  ```text
+  --tasks .forgeflow/tasks
+  --recent 10
+  --format md|json
+  --output optional/path
+  ```
+- Exit 0 for empty/missing tasks root with zero summary.
+
+### Task 4: Document usage
+
+**Files:**
+- Modify: `README.md`
+
+Add a local monitoring section with:
+```bash
+python3 scripts/forgeflow_monitor.py --tasks .forgeflow/tasks --recent 10 --format md
+python3 scripts/forgeflow_monitor.py --tasks .forgeflow/tasks --recent 10 --format json
+```
+
+Explicitly say read-only/local-only and not a dashboard.
+
+### Task 5: Verify and commit
+
+**Commands:**
+```bash
+python -m py_compile scripts/forgeflow_monitor.py
+pytest tests/test_forgeflow_monitor.py -q
+make validate
+python -m pytest -q
+git diff --check
+```
+
+**Commit:**
+```bash
+git add docs/plans/2026-04-24-forgeflow-monitor-summary.md scripts/forgeflow_monitor.py tests/test_forgeflow_monitor.py README.md
+git commit -m "feat: add local forgeflow monitor summary"
+```

--- a/scripts/forgeflow_monitor.py
+++ b/scripts/forgeflow_monitor.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Summarize local ForgeFlow task artifacts without mutating them."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+ARTIFACTS = ("run-state.json", "review-report.json", "eval-record.json", "decision-log.json")
+
+
+def load_json(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    if not path.exists():
+        return None, None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return None, f"{path.name}: {exc.msg}"
+    if not isinstance(data, dict):
+        return None, f"{path.name}: expected object"
+    return data, None
+
+
+def discover_tasks(tasks_root: Path, recent: int) -> list[Path]:
+    if not tasks_root.exists() or not tasks_root.is_dir():
+        return []
+    task_dirs = [path for path in tasks_root.iterdir() if path.is_dir()]
+    task_dirs.sort(key=lambda path: path.stat().st_mtime, reverse=True)
+    if recent > 0:
+        return task_dirs[:recent]
+    return task_dirs
+
+
+def _first_string(*values: Any, default: str = "unknown") -> str:
+    for value in values:
+        if isinstance(value, str) and value:
+            return value
+    return default
+
+
+def _review_status(review: dict[str, Any] | None) -> str:
+    if not review:
+        return "missing"
+    if review.get("approved") is True or review.get("status") in {"approved", "pass", "passed"}:
+        return "approved"
+    if review.get("approved") is False or review.get("status") in {"rejected", "fail", "failed"}:
+        return "rejected"
+    return "unknown"
+
+
+def _finding_messages(review: dict[str, Any] | None) -> list[str]:
+    if not review:
+        return []
+    messages: list[str] = []
+    for finding in review.get("findings", []) or []:
+        if isinstance(finding, dict):
+            message = _first_string(finding.get("message"), finding.get("summary"), finding.get("title"), default="")
+        else:
+            message = str(finding)
+        if message:
+            messages.append(message)
+    return messages
+
+
+def summarize_task(task_dir: Path) -> dict[str, Any]:
+    artifacts: dict[str, dict[str, Any] | None] = {}
+    errors: list[str] = []
+    for name in ARTIFACTS:
+        data, error = load_json(task_dir / name)
+        artifacts[name] = data
+        if error:
+            errors.append(error)
+
+    run_state = artifacts["run-state.json"] or {}
+    review = artifacts["review-report.json"]
+    eval_record = artifacts["eval-record.json"] or {}
+    decision_log = artifacts["decision-log.json"] or {}
+
+    task_id = _first_string(run_state.get("task_id"), run_state.get("id"), task_dir.name)
+    route = _first_string(run_state.get("route"), run_state.get("complexity_route"))
+    stage = _first_string(run_state.get("current_stage"), run_state.get("stage"))
+    status = _first_string(run_state.get("status"))
+    review_status = _review_status(review)
+    eval_status = _first_string(eval_record.get("status"), eval_record.get("verdict"), default="missing")
+
+    failure_messages: list[str] = []
+    for key in ("blocked_reason", "error_message", "failure_reason"):
+        value = run_state.get(key)
+        if isinstance(value, str) and value:
+            failure_messages.append(value)
+    for key in ("reason", "decision", "summary"):
+        value = decision_log.get(key)
+        if isinstance(value, str) and value and status in {"blocked", "error", "failed"}:
+            failure_messages.append(value)
+    if review_status == "rejected":
+        failure_messages.extend(_finding_messages(review))
+
+    return {
+        "task_id": task_id,
+        "path": str(task_dir),
+        "route": route,
+        "current_stage": stage,
+        "status": status,
+        "review_status": review_status,
+        "eval_status": eval_status,
+        "failure_messages": failure_messages,
+        "artifact_errors": errors,
+    }
+
+
+def build_report(task_dirs: list[Path]) -> dict[str, Any]:
+    tasks = [summarize_task(path) for path in task_dirs]
+    summary = {
+        "total_tasks": len(tasks),
+        "completed": sum(1 for task in tasks if task["status"] == "completed"),
+        "blocked": sum(1 for task in tasks if task["status"] == "blocked"),
+        "error": sum(1 for task in tasks if task["status"] in {"error", "failed"}),
+        "unknown": sum(1 for task in tasks if task["status"] == "unknown"),
+        "review_rejected": sum(1 for task in tasks if task["review_status"] == "rejected"),
+        "review_approved": sum(1 for task in tasks if task["review_status"] == "approved"),
+        "artifact_errors": sum(len(task["artifact_errors"]) for task in tasks),
+    }
+    patterns = Counter(message for task in tasks for message in task["failure_messages"])
+    return {
+        "summary": summary,
+        "top_failure_patterns": [
+            {"message": message, "count": count} for message, count in patterns.most_common(10)
+        ],
+        "tasks": tasks,
+    }
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    summary = report["summary"]
+    lines = [
+        "# ForgeFlow monitor summary",
+        "",
+        f"Total tasks: {summary['total_tasks']}",
+        f"Completed: {summary['completed']}",
+        f"Blocked: {summary['blocked']}",
+        f"Error: {summary['error']}",
+        f"Review rejected: {summary['review_rejected']}",
+        f"Artifact errors: {summary['artifact_errors']}",
+        "",
+        "## Top failure patterns",
+        "",
+    ]
+    patterns = report["top_failure_patterns"]
+    if patterns:
+        lines.extend(f"- {item['message']} ({item['count']})" for item in patterns)
+    else:
+        lines.append("- None")
+    lines.extend([
+        "",
+        "## Tasks",
+        "",
+        "| task | route | stage | status | review |",
+        "|---|---|---|---|---|",
+    ])
+    for task in report["tasks"]:
+        lines.append(
+            f"| {task['task_id']} | {task['route']} | {task['current_stage']} | {task['status']} | {task['review_status']} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tasks", default=".forgeflow/tasks", help="Path to the ForgeFlow tasks directory")
+    parser.add_argument("--recent", type=int, default=10, help="Number of most recently modified task directories to inspect; <=0 means all")
+    parser.add_argument("--format", choices=["md", "json"], default="md")
+    parser.add_argument("--output", help="Optional file path to write the report")
+    args = parser.parse_args(argv)
+
+    task_dirs = discover_tasks(Path(args.tasks), args.recent)
+    report = build_report(task_dirs)
+    if args.format == "json":
+        content = json.dumps(report, indent=2, ensure_ascii=False) + "\n"
+    else:
+        content = render_markdown(report)
+
+    if args.output:
+        Path(args.output).write_text(content, encoding="utf-8")
+    else:
+        print(content, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_forgeflow_monitor.py
+++ b/tests/test_forgeflow_monitor.py
@@ -1,0 +1,118 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "forgeflow_monitor.py"
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def make_fixture(root: Path) -> Path:
+    tasks = root / ".forgeflow" / "tasks"
+
+    write_json(
+        tasks / "done-task" / "run-state.json",
+        {"task_id": "done-task", "route": "small", "current_stage": "finalize", "status": "completed"},
+    )
+    write_json(
+        tasks / "done-task" / "review-report.json",
+        {"task_id": "done-task", "approved": True, "findings": []},
+    )
+
+    write_json(
+        tasks / "blocked-task" / "run-state.json",
+        {
+            "task_id": "blocked-task",
+            "route": "medium",
+            "current_stage": "execute",
+            "status": "blocked",
+            "blocked_reason": "missing API key",
+        },
+    )
+
+    write_json(
+        tasks / "rejected-task" / "run-state.json",
+        {"task_id": "rejected-task", "route": "medium", "current_stage": "quality-review", "status": "in_progress"},
+    )
+    write_json(
+        tasks / "rejected-task" / "review-report.json",
+        {
+            "task_id": "rejected-task",
+            "approved": False,
+            "findings": [
+                {"severity": "high", "message": "missing verification evidence"},
+            ],
+        },
+    )
+
+    return tasks
+
+
+def run_monitor(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_monitor_json_summarizes_task_health(tmp_path):
+    tasks = make_fixture(tmp_path)
+
+    result = run_monitor("--tasks", str(tasks), "--format", "json", "--recent", "10")
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["total_tasks"] == 3
+    assert payload["summary"]["completed"] == 1
+    assert payload["summary"]["blocked"] == 1
+    assert payload["summary"]["review_rejected"] == 1
+    assert payload["summary"]["artifact_errors"] == 0
+    patterns = payload["top_failure_patterns"]
+    assert any(item["message"] == "missing API key" for item in patterns)
+    assert any(item["message"] == "missing verification evidence" for item in patterns)
+
+
+def test_monitor_markdown_renders_summary_and_task_rows(tmp_path):
+    tasks = make_fixture(tmp_path)
+
+    result = run_monitor("--tasks", str(tasks), "--format", "md", "--recent", "10")
+
+    assert result.returncode == 0, result.stderr
+    assert "# ForgeFlow monitor summary" in result.stdout
+    assert "Total tasks: 3" in result.stdout
+    assert "Review rejected: 1" in result.stdout
+    assert "| done-task | small | finalize | completed | approved |" in result.stdout
+    assert "| rejected-task | medium | quality-review | in_progress | rejected |" in result.stdout
+
+
+def test_monitor_tolerates_missing_and_malformed_artifacts(tmp_path):
+    tasks = tmp_path / ".forgeflow" / "tasks"
+    (tasks / "empty-task").mkdir(parents=True)
+    bad = tasks / "bad-task" / "run-state.json"
+    bad.parent.mkdir(parents=True)
+    bad.write_text("{not json", encoding="utf-8")
+
+    result = run_monitor("--tasks", str(tasks), "--format", "json")
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["total_tasks"] == 2
+    assert payload["summary"]["unknown"] == 2
+    assert payload["summary"]["artifact_errors"] == 1
+
+
+def test_monitor_missing_tasks_root_returns_empty_summary(tmp_path):
+    result = run_monitor("--tasks", str(tmp_path / "missing"), "--format", "json")
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["total_tasks"] == 0
+    assert payload["tasks"] == []


### PR DESCRIPTION
## Summary
- add a read-only `scripts/forgeflow_monitor.py` CLI for local ForgeFlow task artifacts
- summarize run-state, review, eval, and decision-log signals in markdown or JSON
- add focused pytest coverage for empty dirs, mixed artifacts, invalid JSON, and repeated failures
- document local usage in README

## Test Plan
- `python -m py_compile scripts/forgeflow_monitor.py`
- `pytest tests/test_forgeflow_monitor.py -q`
- `make validate`
- `python -m pytest -q`
- `git diff --check`
