### PR TITLE
docs: align ForgeFlow make-target contracts

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -41,9 +41,10 @@ jobs:
           python-version: '3.11'
 
       - name: Install Python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
+        run: make setup
+
+      - name: Check ForgeFlow environment
+        run: make check-env
 
       - name: Regenerate adapters and fail on drift
-        run: python3 scripts/validate_generated.py
+        run: .venv/bin/python scripts/validate_generated.py

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -109,9 +109,9 @@ make validate
 샘플 실행:
 
 ```bash
-python3 scripts/run_runtime_sample.py \
-  --fixture-dir examples/runtime-fixtures/small-doc-task \
-  --route small
+make setup
+make check-env
+make runtime-sample
 ```
 
 직접 task를 만들 때:

--- a/adapters/targets/codex/agents/forgeflow-coordinator.md
+++ b/adapters/targets/codex/agents/forgeflow-coordinator.md
@@ -19,6 +19,11 @@ You coordinate Codex work through ForgeFlow. Do not turn this into vibes with a 
 - Do not invent npm scripts. Read `package.json` first.
 - Do not mark work complete without evidence from real commands or file checks.
 
+## Recovery contract
+- After an edit/write/apply failure, re-read the target file before retrying.
+- For large files, noisy context, or oversized output, use targeted search or chunked reads.
+- After three repeated failures, stop and change strategy before continuing.
+
 ## Output contract
 Return:
 1. current stage

--- a/adapters/targets/cursor/rules/forgeflow-coordinator.mdc
+++ b/adapters/targets/cursor/rules/forgeflow-coordinator.mdc
@@ -18,3 +18,8 @@ Coordinate Cursor work through ForgeFlow stages and artifacts. Do not let Cursor
 - Treat `.cursor/rules` under the current project as the only Cursor preset location.
 - Do not invent npm scripts. Read `package.json` first.
 - Do not bypass ForgeFlow review gates just because Cursor can edit quickly.
+
+## Recovery contract
+- After an edit/write/apply failure, re-read the target file before retrying.
+- For large files, noisy context, or oversized output, use targeted search or chunked reads.
+- After three repeated failures, stop and change strategy before continuing.

--- a/docs/plans/2026-04-23-engineering-discipline-absorption-plan.md
+++ b/docs/plans/2026-04-23-engineering-discipline-absorption-plan.md
@@ -150,8 +150,7 @@ ForgeFlow has an explicit review model document that matches current policy/runt
 The runtime exists already. The shell story just needs to stop sounding accidental.
 
 **Verification:**
-- Run: `python3 scripts/run_orchestrator.py --help`
-- Run: `python3 scripts/run_orchestrator.py run --help`
+- Run: `make orchestrator-help`
 - Run: `pytest -q tests/test_runtime_orchestrator.py`
 
 **Exit Condition:**

--- a/docs/plans/2026-04-24-claude-hook-recovery.md
+++ b/docs/plans/2026-04-24-claude-hook-recovery.md
@@ -82,7 +82,7 @@ pytest tests/test_claude_recovery_hooks.py -q
 
 **Verification:**
 ```bash
-python3 scripts/validate_claude_hooks.py
+make validate-claude-hooks
 make validate
 ```
 

--- a/docs/plans/2026-04-24-forgeflow-monitor-summary.md
+++ b/docs/plans/2026-04-24-forgeflow-monitor-summary.md
@@ -48,9 +48,11 @@ Minimum useful fields:
    - completed task with approved review
    - blocked task with `blocked_reason`
    - rejected task with `review-report.json` containing findings
-2. Run:
+2. Run through the repo-managed target:
    ```bash
-   python3 scripts/forgeflow_monitor.py --tasks <tmp> --format json --recent 10
+   make setup
+   make check-env
+   make monitor-summary-json
    ```
 3. Assert JSON includes:
    - `summary.total_tasks == 3`

--- a/docs/review-summary-decision.md
+++ b/docs/review-summary-decision.md
@@ -4,11 +4,15 @@ Decision: do not add a first-class `review-summary` command yet.
 
 ## Why
 
-The current operator surface already exposes the useful summary fields through:
+The current operator surface already exposes the useful summary fields through the repo-managed fixture status path:
 
 ```bash
-python3 scripts/run_orchestrator.py status --task-dir <task-dir>
+make setup
+make check-env
+make orchestrator-status
 ```
+
+For non-fixture task directories, operators can still run `status` directly against their chosen task dir when they intentionally step outside the first-clone sample path.
 
 `status` returns:
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,11 +12,11 @@ P0에서 필요한 최소 자동화를 둔다.
 - `run_runtime_sample.py` : runtime sample을 disposable fixture copy에서 실행해서 tracked example이 더러워지지 않게 보호
 
 ## 권장 실행 순서
-1. `python3 scripts/validate_structure.py`
-2. `python3 scripts/validate_policy.py`
-3. `python3 scripts/generate_adapters.py`
-4. `python3 scripts/validate_generated.py`
-5. `python3 scripts/validate_sample_artifacts.py`
+make target이 repo-managed `.venv`를 사용하므로 fresh clone에서는 아래 순서로 실행한다.
+
+make setup
+make check-env
+make validate
 
 ## Runtime sample
 - `python3 scripts/run_runtime_sample.py --fixture-dir examples/runtime-fixtures/small-doc-task --route small`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -19,7 +19,15 @@ make check-env
 make validate
 
 ## Runtime sample
-- `python3 scripts/run_runtime_sample.py --fixture-dir examples/runtime-fixtures/small-doc-task --route small`
+make target이 repo-managed `.venv`를 사용하므로 fresh clone에서는 아래 순서로 실행한다.
+
+```bash
+make setup
+make check-env
+make runtime-sample
+```
+
+- `runtime-sample`은 `scripts/run_runtime_sample.py --fixture-dir examples/runtime-fixtures/small-doc-task --route small`을 repo-managed Python으로 실행한다.
 - `--fixture-dir`는 task fixture 디렉터리를 가리켜야 하며, 파일 경로면 명시적 `ERROR:`로 실패한다.
 - disposable copy에서 실행하므로 tracked fixture가 dirty 상태로 남지 않는다.
 - 임시 workspace는 실행 종료와 함께 지워지므로, 출력에는 disposable workspace 경로를 싣지 않는다.

--- a/tests/test_agent_preset_install.py
+++ b/tests/test_agent_preset_install.py
@@ -54,7 +54,8 @@ def test_generic_installer_installs_codex_nextjs_presets_into_project_only(tmp_p
     result = run_installer(GENERIC_INSTALLER, target, "--adapter", "codex", "--profile", "nextjs")
 
     assert result.returncode == 0, result.stderr
-    assert (target / ".codex/forgeflow/forgeflow-coordinator.md").exists()
+    coordinator = target / ".codex/forgeflow/forgeflow-coordinator.md"
+    assert coordinator.exists()
     assert (target / ".codex/forgeflow/forgeflow-nextjs-worker.md").exists()
     assert (target / ".codex/forgeflow/forgeflow-quality-reviewer.md").exists()
     assert not GLOBAL_CODEX_PRESETS.exists() or before_global_exists
@@ -64,6 +65,7 @@ def test_generic_installer_installs_codex_nextjs_presets_into_project_only(tmp_p
     assert "npm run lint" in text
     assert "npm run test" not in text
     assert "forgeflow-nextjs-worker.md" in text
+    assert "After an edit/write/apply failure, re-read the target file before retrying." in coordinator.read_text(encoding="utf-8")
 
 
 def test_generic_installer_installs_cursor_nextjs_rules_into_project_only(tmp_path):
@@ -74,7 +76,8 @@ def test_generic_installer_installs_cursor_nextjs_rules_into_project_only(tmp_pa
     result = run_installer(GENERIC_INSTALLER, target, "--adapter", "cursor", "--profile", "nextjs")
 
     assert result.returncode == 0, result.stderr
-    assert (target / ".cursor/rules/forgeflow-coordinator.mdc").exists()
+    coordinator = target / ".cursor/rules/forgeflow-coordinator.mdc"
+    assert coordinator.exists()
     assert (target / ".cursor/rules/forgeflow-nextjs-worker.mdc").exists()
     assert (target / ".cursor/rules/forgeflow-quality-reviewer.mdc").exists()
     assert not GLOBAL_CURSOR_RULES.exists() or before_global_exists
@@ -84,6 +87,7 @@ def test_generic_installer_installs_cursor_nextjs_rules_into_project_only(tmp_pa
     assert "npm run lint" in text
     assert "npm run test" not in text
     assert "forgeflow-nextjs-worker.mdc" in text
+    assert "After an edit/write/apply failure, re-read the target file before retrying." in coordinator.read_text(encoding="utf-8")
 
 
 def test_installer_rejects_adapter_config_directory_target(tmp_path):

--- a/tests/test_first_clone_setup.py
+++ b/tests/test_first_clone_setup.py
@@ -73,6 +73,20 @@ def test_install_update_path_rechecks_first_clone_dependencies_before_validation
     assert "새 dependency가 추가된 release" in update_section
 
 
+def test_install_runtime_sample_uses_repo_managed_make_target() -> None:
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    install = (ROOT / "INSTALL.md").read_text(encoding="utf-8")
+    sample_section = install.split("샘플 실행:", 1)[1].split("직접 task를 만들 때:", 1)[0]
+
+    assert "runtime-sample:" in makefile
+    assert "$(VENV_PYTHON) scripts/run_runtime_sample.py --fixture-dir examples/runtime-fixtures/small-doc-task --route small" in makefile
+    assert "make setup" in sample_section
+    assert "make check-env" in sample_section
+    assert "make runtime-sample" in sample_section.splitlines()
+    assert sample_section.index("make setup") < sample_section.index("make check-env") < sample_section.index("make runtime-sample")
+    assert "python3 scripts/run_runtime_sample.py" not in sample_section
+
+
 def test_readme_update_path_keeps_make_commands_in_checkout_context() -> None:
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     update_section = readme.split("### Updating an existing checkout", 1)[1].split("## What ForgeFlow does", 1)[0]

--- a/tests/test_first_clone_setup.py
+++ b/tests/test_first_clone_setup.py
@@ -358,6 +358,20 @@ def test_engineering_discipline_plan_uses_repo_managed_help_target() -> None:
     assert "python3 scripts/run_orchestrator.py run --help" not in verification_section
 
 
+def test_claude_hook_recovery_plan_uses_repo_managed_validation_target() -> None:
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    plan = (ROOT / "docs/plans/2026-04-24-claude-hook-recovery.md").read_text(encoding="utf-8")
+    verification_section = plan.split("**Verification:**", 1)[1].split("**Exit condition:**", 1)[0]
+
+    assert "validate-claude-hooks:" in makefile
+    assert "$(VENV_PYTHON) scripts/validate_claude_hooks.py" in makefile
+    verification_lines = verification_section.splitlines()
+    assert "make validate-claude-hooks" in verification_lines
+    assert "make validate" in verification_lines
+    assert verification_lines.index("make validate-claude-hooks") < verification_lines.index("make validate")
+    assert "python3 scripts/validate_claude_hooks.py" not in verification_section
+
+
 def test_ci_validation_job_creates_venv_before_make_validate() -> None:
     workflow = (ROOT / ".github/workflows/validate.yml").read_text(encoding="utf-8")
     repo_validation_job = workflow.split("  repo-validation:", 1)[1].split("  generated-drift:", 1)[0]

--- a/tests/test_first_clone_setup.py
+++ b/tests/test_first_clone_setup.py
@@ -87,6 +87,27 @@ def test_install_runtime_sample_uses_repo_managed_make_target() -> None:
     assert "python3 scripts/run_runtime_sample.py" not in sample_section
 
 
+def test_scripts_readme_recommends_repo_managed_validate_target() -> None:
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    scripts_readme = (ROOT / "scripts/README.md").read_text(encoding="utf-8")
+    recommended_section = scripts_readme.split("## 권장 실행 순서", 1)[1].split("## Runtime sample", 1)[0]
+
+    assert "validate:" in makefile
+    assert "$(VENV_PYTHON) scripts/validate_structure.py" in makefile
+    assert "$(VENV_PYTHON) scripts/validate_policy.py" in makefile
+    assert "$(VENV_PYTHON) scripts/validate_generated.py" in makefile
+    assert "$(VENV_PYTHON) scripts/validate_sample_artifacts.py" in makefile
+    validate_generated = (ROOT / "scripts/validate_generated.py").read_text(encoding="utf-8")
+    assert "generate_adapters.py" in validate_generated
+    assert "regeneration left adapters/generated clean" in validate_generated
+    assert "make setup" in recommended_section
+    assert "make check-env" in recommended_section
+    assert "make validate" in recommended_section.splitlines()
+    assert recommended_section.index("make setup") < recommended_section.index("make check-env") < recommended_section.index("make validate")
+    assert "python3 scripts/validate_" not in scripts_readme
+    assert "python3 scripts/generate_adapters.py" not in scripts_readme
+
+
 def test_readme_update_path_keeps_make_commands_in_checkout_context() -> None:
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     update_section = readme.split("### Updating an existing checkout", 1)[1].split("## What ForgeFlow does", 1)[0]

--- a/tests/test_first_clone_setup.py
+++ b/tests/test_first_clone_setup.py
@@ -277,6 +277,23 @@ def test_monitoring_summary_plan_points_users_to_make_targets() -> None:
     assert "python3 scripts/forgeflow_monitor.py" not in usage_section
 
 
+def test_monitoring_summary_plan_json_test_command_uses_repo_managed_target() -> None:
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    plan = (ROOT / "docs/plans/2026-04-24-forgeflow-monitor-summary.md").read_text(encoding="utf-8")
+    task_section = plan.split("### Task 1: Add failing tests for JSON summary", 1)[1].split(
+        "### Task 2: Add failing tests for Markdown and graceful fallback", 1
+    )[0]
+
+    assert "monitor-summary-json:" in makefile
+    assert "$(VENV_PYTHON) scripts/forgeflow_monitor.py --tasks .forgeflow/tasks --recent 10 --format json" in makefile
+    assert "make setup" in task_section
+    assert "make check-env" in task_section
+    command_lines = [line.strip() for line in task_section.splitlines()]
+    assert "make monitor-summary-json" in command_lines
+    assert task_section.index("make setup") < task_section.index("make check-env") < task_section.index("make monitor-summary-json")
+    assert "python3 scripts/forgeflow_monitor.py" not in task_section
+
+
 def test_engineering_discipline_plan_uses_repo_managed_help_target() -> None:
     makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
     plan = (ROOT / "docs/plans/2026-04-23-engineering-discipline-absorption-plan.md").read_text(encoding="utf-8")

--- a/tests/test_first_clone_setup.py
+++ b/tests/test_first_clone_setup.py
@@ -277,6 +277,20 @@ def test_monitoring_summary_plan_points_users_to_make_targets() -> None:
     assert "python3 scripts/forgeflow_monitor.py" not in usage_section
 
 
+def test_engineering_discipline_plan_uses_repo_managed_help_target() -> None:
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    plan = (ROOT / "docs/plans/2026-04-23-engineering-discipline-absorption-plan.md").read_text(encoding="utf-8")
+    task_section = plan.split("## P0-3: Tighten operator shell examples", 1)[1].split("# P1 Tasks", 1)[0]
+    verification_section = task_section.split("**Verification:**", 1)[1].split("**Exit Condition:**", 1)[0]
+
+    assert "orchestrator-help:" in makefile
+    assert "$(VENV_PYTHON) scripts/run_orchestrator.py --help" in makefile
+    assert "$(VENV_PYTHON) scripts/run_orchestrator.py run --help" in makefile
+    assert "- Run: `make orchestrator-help`" in verification_section.splitlines()
+    assert "python3 scripts/run_orchestrator.py --help" not in verification_section
+    assert "python3 scripts/run_orchestrator.py run --help" not in verification_section
+
+
 def test_ci_validation_job_creates_venv_before_make_validate() -> None:
     workflow = (ROOT / ".github/workflows/validate.yml").read_text(encoding="utf-8")
     repo_validation_job = workflow.split("  repo-validation:", 1)[1].split("  generated-drift:", 1)[0]

--- a/tests/test_first_clone_setup.py
+++ b/tests/test_first_clone_setup.py
@@ -249,6 +249,21 @@ def test_operator_shell_common_commands_use_repo_managed_status_target_for_read_
     assert "python3 scripts/run_orchestrator.py run" in common_section
 
 
+def test_review_summary_decision_doc_uses_repo_managed_status_target() -> None:
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    doc = (ROOT / "docs/review-summary-decision.md").read_text(encoding="utf-8")
+    current_surface_section = doc.split("## Why", 1)[1].split("## When to reconsider", 1)[0]
+
+    assert "orchestrator-status:" in makefile
+    assert "$(VENV_PYTHON) scripts/run_orchestrator.py status --task-dir examples/runtime-fixtures/small-doc-task" in makefile
+    assert "make setup" in current_surface_section
+    assert "make check-env" in current_surface_section
+    assert "make orchestrator-status" in current_surface_section.splitlines()
+    assert current_surface_section.index("make setup") < current_surface_section.index("make check-env") < current_surface_section.index("make orchestrator-status")
+    assert "For non-fixture task directories, operators can still run `status` directly" in current_surface_section
+    assert "python3 scripts/run_orchestrator.py status" not in current_surface_section
+
+
 def test_monitoring_summary_plan_points_users_to_make_targets() -> None:
     plan = (ROOT / "docs/plans/2026-04-24-forgeflow-monitor-summary.md").read_text(encoding="utf-8")
     usage_section = plan.split("### Task 4: Document usage", 1)[1].split("### Task 5: Verify and commit", 1)[0]

--- a/tests/test_first_clone_setup.py
+++ b/tests/test_first_clone_setup.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -270,6 +271,20 @@ def test_ci_validation_job_creates_venv_before_make_validate() -> None:
     assert "make validate" in repo_validation_job
     assert repo_validation_job.index("make setup") < repo_validation_job.index("make check-env") < repo_validation_job.index("make validate")
     assert ".venv/bin/python -m pytest -q" in repo_validation_job
+
+
+def test_ci_generated_drift_job_uses_repo_managed_venv_before_validation() -> None:
+    workflow = (ROOT / ".github/workflows/validate.yml").read_text(encoding="utf-8")
+    match = re.search(r"^  generated-drift:\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:|\Z)", workflow, re.MULTILINE | re.DOTALL)
+    assert match is not None
+    generated_drift_job = match.group("body")
+
+    assert "make setup" in generated_drift_job
+    assert "make check-env" in generated_drift_job
+    assert ".venv/bin/python scripts/validate_generated.py" in generated_drift_job
+    assert "python -m pip install" not in generated_drift_job
+    assert "python3 scripts/validate_generated.py" not in generated_drift_job
+    assert generated_drift_job.index("make setup") < generated_drift_job.index("make check-env") < generated_drift_job.index(".venv/bin/python scripts/validate_generated.py")
 
 
 def test_readme_documents_project_team_preset_installer() -> None:

--- a/tests/test_first_clone_setup.py
+++ b/tests/test_first_clone_setup.py
@@ -108,6 +108,21 @@ def test_scripts_readme_recommends_repo_managed_validate_target() -> None:
     assert "python3 scripts/generate_adapters.py" not in scripts_readme
 
 
+def test_scripts_readme_runtime_sample_uses_repo_managed_target() -> None:
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    scripts_readme = (ROOT / "scripts/README.md").read_text(encoding="utf-8")
+    runtime_section = scripts_readme.split("## Runtime sample", 1)[1]
+
+    assert "runtime-sample:" in makefile
+    assert "$(VENV_PYTHON) scripts/run_runtime_sample.py --fixture-dir examples/runtime-fixtures/small-doc-task --route small" in makefile
+    assert "make setup" in runtime_section
+    assert "make check-env" in runtime_section
+    assert "make runtime-sample" in runtime_section.splitlines()
+    assert runtime_section.index("make setup") < runtime_section.index("make check-env") < runtime_section.index("make runtime-sample")
+    assert "--fixture-dir`는 task fixture 디렉터리를 가리켜야 하며, 파일 경로면 명시적 `ERROR:`로 실패한다." in runtime_section
+    assert "python3 scripts/run_runtime_sample.py" not in runtime_section
+
+
 def test_readme_update_path_keeps_make_commands_in_checkout_context() -> None:
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     update_section = readme.split("### Updating an existing checkout", 1)[1].split("## What ForgeFlow does", 1)[0]

--- a/tests/test_review_findings_hardening.py
+++ b/tests/test_review_findings_hardening.py
@@ -23,8 +23,9 @@ def _load_module(path: Path, name: str):
 def test_ci_installs_requirements_and_runs_full_pytest_suite() -> None:
     workflow = (ROOT / ".github" / "workflows" / "validate.yml").read_text(encoding="utf-8")
 
-    assert "python -m pip install -r requirements.txt" in workflow
-    assert "python -m pytest -q" in workflow
+    assert "run: make setup" in workflow
+    assert "run: make check-env" in workflow
+    assert "run: .venv/bin/python -m pytest -q" in workflow
 
 
 def test_check_environment_reports_missing_venv_support(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_validate_structure.py
+++ b/tests/test_validate_structure.py
@@ -62,10 +62,13 @@ def test_validate_structure_tracks_runtime_and_memory_scaffold() -> None:
 
 def test_validate_workflow_installs_policy_validator_dependencies() -> None:
     workflow = (ROOT / ".github" / "workflows" / "validate.yml").read_text(encoding="utf-8").lower()
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8").lower()
 
     requirements = (ROOT / "requirements.txt").read_text(encoding="utf-8").lower()
 
-    assert "-r requirements.txt" in workflow
+    assert "run: make setup" in workflow
+    assert "run: make check-env" in workflow
+    assert "-r requirements.txt" in makefile
     assert "jsonschema" in requirements
     assert "pyyaml" in requirements
     assert "pytest" in requirements


### PR DESCRIPTION
## Summary
- route remaining ForgeFlow docs and plans through repo-managed Make targets for validation/status/help/runtime sample flows
- align generated-drift CI with repo setup/check-env and venv validation paths
- strengthen codex/cursor coordinator preset recovery contract coverage
- add focused first-clone/docs contract regressions so examples do not drift back to direct script invocations
- update stale CI install-contract tests to reflect `make setup` / `make check-env` as the dependency boundary

## Review
- Claude current-state analysis: repo safe/clean; changes are low-risk maintenance focused on runtime contract hardening
- Codex current-state analysis: PR packaging recommended now; biggest risk was validation evidence, addressed below

## Test Plan
- `python -m pytest tests/test_review_findings_hardening.py tests/test_validate_structure.py -q`
- `make validate`
- `python -m pytest -q` — 354 passed
- `git diff --check`
