### PR TITLE
refactor: extract forgeflow runtime seams

### DIFF
--- a/forgeflow_runtime/operator_routing.py
+++ b/forgeflow_runtime/operator_routing.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Callable, TypeVar
+
+ViolationT = TypeVar("ViolationT", bound=Exception)
+
+STAGE_ROLE_MAP: dict[str, str] = {
+    "clarify": "coordinator",
+    "plan": "planner",
+    "execute": "worker",
+    "spec-review": "spec-reviewer",
+    "quality-review": "quality-reviewer",
+    "finalize": "coordinator",
+    "long-run": "worker",
+}
+
+ROUTE_ORDER: list[str] = ["small", "medium", "large_high_risk"]
+RISK_TO_ROUTE: dict[str, str] = {
+    "low": "small",
+    "medium": "medium",
+    "high": "large_high_risk",
+}
+
+
+def role_for_stage(
+    stage: str,
+    *,
+    violation_factory: Callable[[str], ViolationT] = ValueError,
+) -> str:
+    role = STAGE_ROLE_MAP.get(stage)
+    if not role:
+        raise violation_factory(f"no default role mapping for stage: {stage}")
+    return role
+
+
+def route_rank(
+    route_name: str,
+    *,
+    violation_factory: Callable[[str], ViolationT] = ValueError,
+) -> int:
+    if route_name not in ROUTE_ORDER:
+        raise violation_factory(f"unknown route: {route_name}")
+    return ROUTE_ORDER.index(route_name)
+
+
+def auto_route_for_task_dir(task_dir: Path) -> str:
+    for artifact_name in ["session-state.json", "checkpoint.json", "plan-ledger.json"]:
+        path = task_dir / artifact_name
+        if not path.exists():
+            continue
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        route_name = payload.get("route")
+        if isinstance(route_name, str) and route_name:
+            return route_name
+
+    brief_path = task_dir / "brief.json"
+    if brief_path.exists():
+        brief = json.loads(brief_path.read_text(encoding="utf-8"))
+        risk_level = brief.get("risk_level")
+        if isinstance(risk_level, str) and risk_level in RISK_TO_ROUTE:
+            return RISK_TO_ROUTE[risk_level]
+
+    return "small"
+
+
+def effective_route(
+    *,
+    task_dir: Path,
+    explicit_route: str | None,
+    min_route: str | None,
+    violation_factory: Callable[[str], ViolationT] = ValueError,
+) -> str:
+    route_name = explicit_route or auto_route_for_task_dir(task_dir)
+    if min_route is None:
+        return route_name
+    return ROUTE_ORDER[
+        max(
+            route_rank(route_name, violation_factory=violation_factory),
+            route_rank(min_route, violation_factory=violation_factory),
+        )
+    ]

--- a/forgeflow_runtime/orchestrator.py
+++ b/forgeflow_runtime/orchestrator.py
@@ -37,6 +37,7 @@ from forgeflow_runtime.plan_ledger import (
 )
 from forgeflow_runtime.policy_loader import RuntimePolicy, load_runtime_policy
 from forgeflow_runtime.resume_validation import resume_start_index
+from forgeflow_runtime.route_execution import route_iteration_stages
 from forgeflow_runtime.stage_transition import next_stage_for_transition
 from forgeflow_runtime.task_identity import canonical_task_id as _canonical_task_id
 from forgeflow_runtime.task_identity import task_id as _task_id
@@ -1017,7 +1018,7 @@ def run_route(task_dir: Path, policy: RuntimePolicy, route_name: str) -> dict[st
             rationale="validated checkpoint state reused instead of replaying prior stages",
         )
 
-    for stage_name in route[start_index:]:
+    for stage_name in route_iteration_stages(route, start_index):
         missing_artifacts = _missing_artifacts(task_dir, policy.stage_requirements.get(stage_name, []))
         if missing_artifacts:
             raise RuntimeViolation(

--- a/forgeflow_runtime/orchestrator.py
+++ b/forgeflow_runtime/orchestrator.py
@@ -37,7 +37,7 @@ from forgeflow_runtime.plan_ledger import (
 )
 from forgeflow_runtime.policy_loader import RuntimePolicy, load_runtime_policy
 from forgeflow_runtime.resume_validation import resume_start_index
-from forgeflow_runtime.route_execution import route_entry_decision, route_iteration_stages
+from forgeflow_runtime.route_execution import route_entry_decision, route_iteration_stages, stage_completion_status
 from forgeflow_runtime.stage_transition import next_stage_for_transition
 from forgeflow_runtime.task_identity import canonical_task_id as _canonical_task_id
 from forgeflow_runtime.task_identity import task_id as _task_id
@@ -1045,13 +1045,15 @@ def run_route(task_dir: Path, policy: RuntimePolicy, route_name: str) -> dict[st
                 raise RuntimeViolation(
                     f"finalize requires run-state approval flags: {', '.join(missing_flags)}"
                 )
-            run_state["status"] = "completed"
-            run_state["final_status"] = "success"
-            _finalize_plan_ledger_task(plan_ledger)
 
-        if stage_name == "long-run":
-            run_state["status"] = "completed"
-            run_state["final_status"] = run_state.get("final_status", "success")
+        status, final_status = stage_completion_status(
+            stage_name,
+            existing_final_status=run_state.get("final_status"),
+        )
+        run_state["status"] = status
+        if final_status is not None:
+            run_state["final_status"] = final_status
+        if stage_name in {"finalize", "long-run"}:
             _finalize_plan_ledger_task(plan_ledger)
 
         _append_decision(

--- a/forgeflow_runtime/orchestrator.py
+++ b/forgeflow_runtime/orchestrator.py
@@ -37,7 +37,7 @@ from forgeflow_runtime.plan_ledger import (
 )
 from forgeflow_runtime.policy_loader import RuntimePolicy, load_runtime_policy
 from forgeflow_runtime.resume_validation import resume_start_index
-from forgeflow_runtime.route_execution import route_iteration_stages
+from forgeflow_runtime.route_execution import route_entry_decision, route_iteration_stages
 from forgeflow_runtime.stage_transition import next_stage_for_transition
 from forgeflow_runtime.task_identity import canonical_task_id as _canonical_task_id
 from forgeflow_runtime.task_identity import task_id as _task_id
@@ -973,13 +973,20 @@ def run_route(task_dir: Path, policy: RuntimePolicy, route_name: str) -> dict[st
         plan_ledger=plan_ledger,
     )
 
-    if start_index >= len(route):
+    route_entry = route_entry_decision(
+        route_name=route_name,
+        start_index=start_index,
+        resume_from_stage=resume_from_stage,
+        route_length=len(route),
+    )
+
+    if route_entry.already_complete:
         _append_decision(
             decision_log,
             actor="orchestrator",
             category="routing",
-            decision=f"route already complete: {route_name}",
-            rationale="validated checkpoint already reached route terminal stage",
+            decision=route_entry.decision,
+            rationale=route_entry.rationale,
         )
         _write_validated_artifact(task_dir, "decision-log", decision_log)
         _write_validated_artifact(task_dir, "run-state", run_state)
@@ -1001,22 +1008,13 @@ def run_route(task_dir: Path, policy: RuntimePolicy, route_name: str) -> dict[st
         )
         return run_state
 
-    if start_index == 0:
-        _append_decision(
-            decision_log,
-            actor="orchestrator",
-            category="routing",
-            decision=f"route selected: {route_name}",
-            rationale="canonical complexity route applied",
-        )
-    else:
-        _append_decision(
-            decision_log,
-            actor="orchestrator",
-            category="routing",
-            decision=f"route resumed: {route_name} from {resume_from_stage}",
-            rationale="validated checkpoint state reused instead of replaying prior stages",
-        )
+    _append_decision(
+        decision_log,
+        actor="orchestrator",
+        category="routing",
+        decision=route_entry.decision,
+        rationale=route_entry.rationale,
+    )
 
     for stage_name in route_iteration_stages(route, start_index):
         missing_artifacts = _missing_artifacts(task_dir, policy.stage_requirements.get(stage_name, []))

--- a/forgeflow_runtime/orchestrator.py
+++ b/forgeflow_runtime/orchestrator.py
@@ -37,6 +37,7 @@ from forgeflow_runtime.plan_ledger import (
 )
 from forgeflow_runtime.policy_loader import RuntimePolicy, load_runtime_policy
 from forgeflow_runtime.resume_validation import resume_start_index
+from forgeflow_runtime.stage_transition import next_stage_for_transition
 from forgeflow_runtime.task_identity import canonical_task_id as _canonical_task_id
 from forgeflow_runtime.task_identity import task_id as _task_id
 
@@ -840,11 +841,7 @@ def advance_to_next_stage(
             f"requested current_stage {current_stage} does not match persisted run-state stage {run_state.get('current_stage')}"
         )
 
-    current_index = route.index(current_stage)
-    if current_index + 1 >= len(route):
-        raise RuntimeViolation(f"stage {current_stage} has no next stage in route {route_name}")
-
-    next_stage = route[current_index + 1]
+    next_stage = next_stage_for_transition(route, current_stage, route_name=route_name, violation_factory=RuntimeViolation)
     missing_artifacts = _missing_artifacts(task_dir, policy.stage_requirements.get(next_stage, []))
     if missing_artifacts:
         raise RuntimeViolation(

--- a/forgeflow_runtime/orchestrator.py
+++ b/forgeflow_runtime/orchestrator.py
@@ -35,6 +35,7 @@ from forgeflow_runtime.plan_ledger import (
     sync_plan_ledger_retry as _sync_plan_ledger_retry,
     sync_plan_ledger_review as _sync_plan_ledger_review,
 )
+from forgeflow_runtime.operator_routing import role_for_stage
 from forgeflow_runtime.policy_loader import RuntimePolicy, load_runtime_policy
 from forgeflow_runtime.resume_validation import resume_start_index
 from forgeflow_runtime.route_execution import route_entry_decision, route_iteration_stages, stage_completion_status
@@ -887,18 +888,7 @@ def advance_to_next_stage(
     if execute_immediately:
         from forgeflow_runtime.engine import execute_stage
 
-        default_role_map = {
-            "clarify": "coordinator",
-            "plan": "planner",
-            "execute": "worker",
-            "spec-review": "spec-reviewer",
-            "quality-review": "quality-reviewer",
-            "finalize": "coordinator",
-            "long-run": "worker",
-        }
-        execution_role = role or default_role_map.get(next_stage)
-        if not execution_role:
-            raise RuntimeViolation(f"no default role mapping for stage: {next_stage}")
+        execution_role = role or role_for_stage(next_stage, violation_factory=RuntimeViolation)
         result = execute_stage(
             task_dir=task_dir,
             task_id=staged_run_state.get("task_id", canonical_task_id),

--- a/forgeflow_runtime/route_execution.py
+++ b/forgeflow_runtime/route_execution.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+def route_iteration_stages(route: list[str], start_index: int) -> list[str]:
+    return list(route[start_index:])

--- a/forgeflow_runtime/route_execution.py
+++ b/forgeflow_runtime/route_execution.py
@@ -1,5 +1,38 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RouteEntryDecision:
+    decision: str
+    rationale: str
+    already_complete: bool = False
+
+
+def route_entry_decision(
+    *,
+    route_name: str,
+    start_index: int,
+    resume_from_stage: str | None,
+    route_length: int,
+) -> RouteEntryDecision:
+    if start_index >= route_length:
+        return RouteEntryDecision(
+            decision=f"route already complete: {route_name}",
+            rationale="validated checkpoint already reached route terminal stage",
+            already_complete=True,
+        )
+    if start_index == 0:
+        return RouteEntryDecision(
+            decision=f"route selected: {route_name}",
+            rationale="canonical complexity route applied",
+        )
+    return RouteEntryDecision(
+        decision=f"route resumed: {route_name} from {resume_from_stage}",
+        rationale="validated checkpoint state reused instead of replaying prior stages",
+    )
+
 
 def route_iteration_stages(route: list[str], start_index: int) -> list[str]:
     return list(route[start_index:])

--- a/forgeflow_runtime/route_execution.py
+++ b/forgeflow_runtime/route_execution.py
@@ -36,3 +36,11 @@ def route_entry_decision(
 
 def route_iteration_stages(route: list[str], start_index: int) -> list[str]:
     return list(route[start_index:])
+
+
+def stage_completion_status(stage_name: str, *, existing_final_status: str | None) -> tuple[str, str | None]:
+    if stage_name == "finalize":
+        return "completed", "success"
+    if stage_name == "long-run":
+        return "completed", existing_final_status or "success"
+    return "in_progress", existing_final_status

--- a/forgeflow_runtime/stage_transition.py
+++ b/forgeflow_runtime/stage_transition.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from forgeflow_runtime.errors import RuntimeViolation
+
+
+def next_stage_for_transition(
+    route: list[str],
+    current_stage: str,
+    *,
+    route_name: str,
+    violation_factory: Callable[[str], Exception] = RuntimeViolation,
+) -> str:
+    if current_stage not in route:
+        raise violation_factory(f"stage {current_stage} is not part of route {route_name}")
+
+    current_index = route.index(current_stage)
+    if current_index + 1 >= len(route):
+        raise violation_factory(f"stage {current_stage} has no next stage in route {route_name}")
+
+    return route[current_index + 1]

--- a/scripts/run_orchestrator.py
+++ b/scripts/run_orchestrator.py
@@ -23,6 +23,7 @@ from forgeflow_runtime.orchestrator import (  # noqa: E402
     status_summary,
     step_back,
 )
+from forgeflow_runtime.operator_routing import ROUTE_ORDER, effective_route, role_for_stage  # noqa: E402
 from forgeflow_runtime.engine import execute_stage  # noqa: E402
 from forgeflow_runtime.executor import ExecutorError  # noqa: E402
 from forgeflow_runtime.generator import GenerationError  # noqa: E402
@@ -45,64 +46,6 @@ def _execution_payload(*, stage: str, role: str, adapter: str, result, use_real:
 
 def _print_payload(payload: dict) -> None:
     print(json.dumps(payload, indent=2, ensure_ascii=False))
-
-
-STAGE_ROLE_MAP: dict[str, str] = {
-    "clarify": "coordinator",
-    "plan": "planner",
-    "execute": "worker",
-    "spec-review": "spec-reviewer",
-    "quality-review": "quality-reviewer",
-    "finalize": "coordinator",
-    "long-run": "worker",
-}
-
-ROUTE_ORDER: list[str] = ["small", "medium", "large_high_risk"]
-RISK_TO_ROUTE: dict[str, str] = {
-    "low": "small",
-    "medium": "medium",
-    "high": "large_high_risk",
-}
-
-
-def _role_for_stage(stage: str) -> str:
-    role = STAGE_ROLE_MAP.get(stage)
-    if not role:
-        raise RuntimeViolation(f"no default role mapping for stage: {stage}")
-    return role
-
-
-def _route_rank(route_name: str) -> int:
-    if route_name not in ROUTE_ORDER:
-        raise RuntimeViolation(f"unknown route: {route_name}")
-    return ROUTE_ORDER.index(route_name)
-
-
-def _auto_route_for_task_dir(task_dir: Path) -> str:
-    for artifact_name in ["session-state.json", "checkpoint.json", "plan-ledger.json"]:
-        path = task_dir / artifact_name
-        if not path.exists():
-            continue
-        payload = json.loads(path.read_text(encoding="utf-8"))
-        route_name = payload.get("route")
-        if isinstance(route_name, str) and route_name:
-            return route_name
-
-    brief_path = task_dir / "brief.json"
-    if brief_path.exists():
-        brief = json.loads(brief_path.read_text(encoding="utf-8"))
-        risk_level = brief.get("risk_level")
-        if isinstance(risk_level, str) and risk_level in RISK_TO_ROUTE:
-            return RISK_TO_ROUTE[risk_level]
-
-    return "small"
-
-
-def _effective_route(*, task_dir: Path, explicit_route: str | None, min_route: str | None) -> str:
-    route_name = explicit_route or _auto_route_for_task_dir(task_dir)
-    if min_route is None:
-        return route_name
-    return ROUTE_ORDER[max(_route_rank(route_name), _route_rank(min_route))]
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -241,10 +184,11 @@ def main() -> int:
     policy = load_runtime_policy(ROOT)
 
     try:
-        route_name = _effective_route(
+        route_name = effective_route(
             task_dir=task_dir,
             explicit_route=getattr(args, "route", None),
             min_route=getattr(args, "min_route", None),
+            violation_factory=RuntimeViolation,
         )
         if args.command == "start":
             _print_payload(start_task(task_dir=task_dir, policy=policy, route_name=route_name))
@@ -298,7 +242,7 @@ def main() -> int:
             if not current_stage:
                 print("ERROR: current_stage not set in run-state.", file=sys.stderr)
                 return 1
-            role = args.role or _role_for_stage(current_stage)
+            role = args.role or role_for_stage(current_stage, violation_factory=RuntimeViolation)
             result = execute_stage(
                 task_dir=task_dir,
                 task_id=run_state.get("task_id", "unknown"),

--- a/tests/runtime/test_operator_routing.py
+++ b/tests/runtime/test_operator_routing.py
@@ -1,0 +1,34 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from forgeflow_runtime.operator_routing import effective_route, role_for_stage
+from forgeflow_runtime.orchestrator import RuntimeViolation
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def test_effective_route_uses_explicit_route_before_artifacts(tmp_path: Path) -> None:
+    _write_json(tmp_path / "checkpoint.json", {"route": "large_high_risk"})
+
+    assert effective_route(task_dir=tmp_path, explicit_route="small", min_route=None) == "small"
+
+
+def test_effective_route_promotes_auto_detected_route_to_minimum(tmp_path: Path) -> None:
+    _write_json(tmp_path / "brief.json", {"risk_level": "low"})
+
+    assert effective_route(task_dir=tmp_path, explicit_route=None, min_route="medium") == "medium"
+
+
+def test_effective_route_reads_existing_runtime_artifact_route(tmp_path: Path) -> None:
+    _write_json(tmp_path / "session-state.json", {"route": "large_high_risk"})
+
+    assert effective_route(task_dir=tmp_path, explicit_route=None, min_route=None) == "large_high_risk"
+
+
+def test_role_for_stage_rejects_unknown_stage() -> None:
+    with pytest.raises(RuntimeViolation, match="no default role mapping"):
+        role_for_stage("bogus", violation_factory=RuntimeViolation)

--- a/tests/runtime/test_route_execution.py
+++ b/tests/runtime/test_route_execution.py
@@ -5,7 +5,7 @@ import pytest
 from jsonschema import Draft202012Validator
 
 from forgeflow_runtime.orchestrator import RuntimeViolation, load_runtime_policy, run_route
-from forgeflow_runtime.route_execution import route_entry_decision, route_iteration_stages
+from forgeflow_runtime.route_execution import route_entry_decision, route_iteration_stages, stage_completion_status
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -49,6 +49,7 @@ def test_route_entry_decision_marks_complete_route() -> None:
     assert decision.already_complete is True
 
 
+<<<<<<< HEAD
 def _write_json(path: Path, payload: dict) -> None:
     path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
@@ -63,6 +64,25 @@ def _assert_schema_valid(name: str, payload: dict) -> None:
 
 
 def test_small_route_runs_end_to_end_and_updates_state(tmp_path: Path) -> None:
+=======
+def test_stage_completion_status_marks_finalize_success() -> None:
+    assert stage_completion_status("finalize", existing_final_status=None) == ("completed", "success")
+
+
+def test_stage_completion_status_preserves_long_run_final_status() -> None:
+    assert stage_completion_status("long-run", existing_final_status="partial") == ("completed", "partial")
+
+
+def test_stage_completion_status_leaves_intermediate_stage_in_progress() -> None:
+    assert stage_completion_status("quality-review", existing_final_status=None) == ("in_progress", None)
+
+
+def test_small_route_runs_end_to_end_and_updates_state(
+    tmp_path: Path,
+    write_json: Callable[[Path, dict], None],
+    assert_schema_valid: Callable[[str, dict], None],
+) -> None:
+>>>>>>> 9c70586 (refactor: extract route completion status seam)
     policy = load_runtime_policy(ROOT)
     task_dir = tmp_path / "task"
     task_dir.mkdir()

--- a/tests/runtime/test_route_execution.py
+++ b/tests/runtime/test_route_execution.py
@@ -5,7 +5,7 @@ import pytest
 from jsonschema import Draft202012Validator
 
 from forgeflow_runtime.orchestrator import RuntimeViolation, load_runtime_policy, run_route
-from forgeflow_runtime.route_execution import route_iteration_stages
+from forgeflow_runtime.route_execution import route_entry_decision, route_iteration_stages
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -15,6 +15,38 @@ def test_route_iteration_stages_starts_at_resume_index() -> None:
     route = ["clarify", "plan", "execute", "quality-review", "finalize"]
 
     assert route_iteration_stages(route, 2) == ["execute", "quality-review", "finalize"]
+
+
+def test_route_entry_decision_selects_new_route() -> None:
+    decision = route_entry_decision(route_name="small", start_index=0, resume_from_stage=None, route_length=4)
+
+    assert decision.decision == "route selected: small"
+    assert decision.rationale == "canonical complexity route applied"
+
+
+def test_route_entry_decision_resumes_from_validated_stage() -> None:
+    decision = route_entry_decision(
+        route_name="medium",
+        start_index=2,
+        resume_from_stage="execute",
+        route_length=5,
+    )
+
+    assert decision.decision == "route resumed: medium from execute"
+    assert decision.rationale == "validated checkpoint state reused instead of replaying prior stages"
+
+
+def test_route_entry_decision_marks_complete_route() -> None:
+    decision = route_entry_decision(
+        route_name="small",
+        start_index=4,
+        resume_from_stage="finalize",
+        route_length=4,
+    )
+
+    assert decision.decision == "route already complete: small"
+    assert decision.rationale == "validated checkpoint already reached route terminal stage"
+    assert decision.already_complete is True
 
 
 def _write_json(path: Path, payload: dict) -> None:

--- a/tests/runtime/test_route_execution.py
+++ b/tests/runtime/test_route_execution.py
@@ -49,7 +49,18 @@ def test_route_entry_decision_marks_complete_route() -> None:
     assert decision.already_complete is True
 
 
-<<<<<<< HEAD
+def test_stage_completion_status_marks_finalize_success() -> None:
+    assert stage_completion_status("finalize", existing_final_status=None) == ("completed", "success")
+
+
+def test_stage_completion_status_preserves_long_run_final_status() -> None:
+    assert stage_completion_status("long-run", existing_final_status="partial") == ("completed", "partial")
+
+
+def test_stage_completion_status_leaves_intermediate_stage_in_progress() -> None:
+    assert stage_completion_status("quality-review", existing_final_status=None) == ("in_progress", None)
+
+
 def _write_json(path: Path, payload: dict) -> None:
     path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
@@ -64,25 +75,6 @@ def _assert_schema_valid(name: str, payload: dict) -> None:
 
 
 def test_small_route_runs_end_to_end_and_updates_state(tmp_path: Path) -> None:
-=======
-def test_stage_completion_status_marks_finalize_success() -> None:
-    assert stage_completion_status("finalize", existing_final_status=None) == ("completed", "success")
-
-
-def test_stage_completion_status_preserves_long_run_final_status() -> None:
-    assert stage_completion_status("long-run", existing_final_status="partial") == ("completed", "partial")
-
-
-def test_stage_completion_status_leaves_intermediate_stage_in_progress() -> None:
-    assert stage_completion_status("quality-review", existing_final_status=None) == ("in_progress", None)
-
-
-def test_small_route_runs_end_to_end_and_updates_state(
-    tmp_path: Path,
-    write_json: Callable[[Path, dict], None],
-    assert_schema_valid: Callable[[str, dict], None],
-) -> None:
->>>>>>> 9c70586 (refactor: extract route completion status seam)
     policy = load_runtime_policy(ROOT)
     task_dir = tmp_path / "task"
     task_dir.mkdir()

--- a/tests/runtime/test_route_execution.py
+++ b/tests/runtime/test_route_execution.py
@@ -5,9 +5,16 @@ import pytest
 from jsonschema import Draft202012Validator
 
 from forgeflow_runtime.orchestrator import RuntimeViolation, load_runtime_policy, run_route
+from forgeflow_runtime.route_execution import route_iteration_stages
 
 
 ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_route_iteration_stages_starts_at_resume_index() -> None:
+    route = ["clarify", "plan", "execute", "quality-review", "finalize"]
+
+    assert route_iteration_stages(route, 2) == ["execute", "quality-review", "finalize"]
 
 
 def _write_json(path: Path, payload: dict) -> None:

--- a/tests/runtime/test_stage_transition.py
+++ b/tests/runtime/test_stage_transition.py
@@ -1,0 +1,24 @@
+import pytest
+
+from forgeflow_runtime.errors import RuntimeViolation
+from forgeflow_runtime.stage_transition import next_stage_for_transition
+
+
+def test_next_stage_for_transition_advances_to_following_route_stage() -> None:
+    route = ["clarify", "plan", "execute"]
+
+    assert next_stage_for_transition(route, "plan", route_name="medium") == "execute"
+
+
+def test_next_stage_for_transition_rejects_stage_outside_route() -> None:
+    route = ["clarify", "plan", "execute"]
+
+    with pytest.raises(RuntimeViolation, match="stage spec-review is not part of route medium"):
+        next_stage_for_transition(route, "spec-review", route_name="medium")
+
+
+def test_next_stage_for_transition_rejects_terminal_stage() -> None:
+    route = ["clarify", "plan", "execute"]
+
+    with pytest.raises(RuntimeViolation, match="stage execute has no next stage in route medium"):
+        next_stage_for_transition(route, "execute", route_name="medium")


### PR DESCRIPTION
## Summary
- Extract runtime seam helpers for stage transition, route iteration, route entry, route completion, and operator routing
- Move default stage-role mapping to `forgeflow_runtime.operator_routing.role_for_stage`
- Thin `scripts/run_orchestrator.py` by delegating runtime decisions to shared seams

## Test Plan
- `git diff --check`
- `make validate`
- `python -m pytest -q` → 396 passed

## Review Notes
Stacked PR 1/3. Base: `main`.

Merge this before #2 and #3.