### PR TITLE
test: consolidate forgeflow runtime fixtures

### DIFF
--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -1,0 +1,116 @@
+import json
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture
+def write_json() -> Callable[[Path, dict], None]:
+    def _write_json(path: Path, payload: dict) -> None:
+        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    return _write_json
+
+
+@pytest.fixture
+def make_task_dir(write_json: Callable[[Path, dict], None]) -> Callable[[Path], Path]:
+    def _make_task_dir(tmp_path: Path) -> Path:
+        task_dir = tmp_path / "task"
+        task_dir.mkdir()
+        write_json(
+            task_dir / "brief.json",
+            {
+                "schema_version": "0.1",
+                "task_id": "task-001",
+                "objective": "Run a small route",
+                "in_scope": ["runtime"],
+                "out_of_scope": [],
+                "constraints": ["local only"],
+                "acceptance_criteria": ["route works"],
+                "risk_level": "low",
+            },
+        )
+        write_json(
+            task_dir / "run-state.json",
+            {
+                "schema_version": "0.1",
+                "task_id": "task-001",
+                "current_stage": "clarify",
+                "status": "in_progress",
+                "completed_gates": ["clarification_complete"],
+                "failed_gates": [],
+                "retries": {},
+                "current_task_id": "",
+                "spec_review_approved": False,
+                "quality_review_approved": False,
+            },
+        )
+        return task_dir
+
+    return _make_task_dir
+
+
+@pytest.fixture
+def medium_plan_artifacts(write_json: Callable[[Path, dict], None]) -> Callable[..., None]:
+    def _write_medium_plan_artifacts(task_dir: Path, *, route_name: str = "medium") -> None:
+        write_json(
+            task_dir / "plan.json",
+            {
+                "schema_version": "0.1",
+                "task_id": "task-001",
+                "steps": [
+                    {
+                        "id": "step-1",
+                        "objective": "update workflow docs",
+                        "dependencies": [],
+                        "expected_output": "workflow docs reflect medium route behavior",
+                        "verification": "pytest tests/runtime -q",
+                        "rollback_note": "remove incomplete workflow edits if validation fails",
+                    }
+                ],
+            },
+        )
+        write_json(
+            task_dir / "plan-ledger.json",
+            {
+                "schema_version": "0.1",
+                "task_id": "task-001",
+                "route": route_name,
+                "completed_stages": [],
+                "completed_gates": [],
+                "retries": {},
+                "current_task_id": "task-1",
+                "tasks": [
+                    {
+                        "id": "task-1",
+                        "title": "update workflow docs",
+                        "depends_on": [],
+                        "files": ["docs/workflow.md"],
+                        "parallel_safe": False,
+                        "status": "in_progress",
+                        "required_gates": ["machine", "validator"],
+                        "evidence_refs": [],
+                        "attempt_count": 0,
+                    }
+                ],
+            },
+        )
+
+    return _write_medium_plan_artifacts
+
+
+@pytest.fixture
+def assert_schema_valid() -> Callable[[str, dict], None]:
+    def _load_schema(name: str) -> dict:
+        return json.loads((ROOT / "schemas" / f"{name}.schema.json").read_text(encoding="utf-8"))
+
+    def _assert_schema_valid(name: str, payload: dict) -> None:
+        errors = sorted(Draft202012Validator(_load_schema(name)).iter_errors(payload), key=lambda err: list(err.path))
+        assert not errors, [f"{list(err.path)}: {err.message}" for err in errors]
+
+    return _assert_schema_valid

--- a/tests/runtime/test_artifact_validation.py
+++ b/tests/runtime/test_artifact_validation.py
@@ -1,8 +1,8 @@
 import json
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
-from jsonschema import Draft202012Validator
 
 from forgeflow_runtime.artifact_validation import load_validated_artifact
 from forgeflow_runtime.orchestrator import RuntimeViolation, load_runtime_policy, retry_stage, run_route
@@ -11,67 +11,29 @@ from forgeflow_runtime.orchestrator import RuntimeViolation, load_runtime_policy
 ROOT = Path(__file__).resolve().parents[2]
 
 
-def _write_json(path: Path, payload: dict) -> None:
-    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
-
-def _load_schema(name: str) -> dict:
-    return json.loads((ROOT / "schemas" / f"{name}.schema.json").read_text(encoding="utf-8"))
-
-
-def _assert_schema_valid(name: str, payload: dict) -> None:
-    errors = sorted(Draft202012Validator(_load_schema(name)).iter_errors(payload), key=lambda err: list(err.path))
-    assert not errors, [f"{list(err.path)}: {err.message}" for err in errors]
-
-
-def _make_task_dir(tmp_path: Path) -> Path:
-    task_dir = tmp_path / "task"
-    task_dir.mkdir()
-    _write_json(
-        task_dir / "brief.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "objective": "Run a small route",
-            "in_scope": ["runtime"],
-            "out_of_scope": [],
-            "constraints": ["local only"],
-            "acceptance_criteria": ["route works"],
-            "risk_level": "low",
-        },
-    )
-    _write_json(
-        task_dir / "run-state.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "current_stage": "clarify",
-            "status": "in_progress",
-            "completed_gates": ["clarification_complete"],
-            "failed_gates": [],
-            "retries": {},
-            "current_task_id": "",
-            "spec_review_approved": False,
-            "quality_review_approved": False,
-        },
-    )
-    return task_dir
-
-
-def test_load_validated_artifact_rejects_unknown_schema_version_with_clear_error(tmp_path: Path) -> None:
-    task_dir = _make_task_dir(tmp_path)
+def test_load_validated_artifact_rejects_unknown_schema_version_with_clear_error(
+    tmp_path: Path,
+    make_task_dir: Callable[[Path], Path],
+    write_json: Callable[[Path, dict], None],
+) -> None:
+    task_dir = make_task_dir(tmp_path)
     run_state = json.loads((task_dir / "run-state.json").read_text(encoding="utf-8"))
     run_state["schema_version"] = "9.9"
-    _write_json(task_dir / "run-state.json", run_state)
+    write_json(task_dir / "run-state.json", run_state)
 
     with pytest.raises(RuntimeViolation, match="run-state.json uses unsupported schema_version 9.9"):
         load_validated_artifact(task_dir, "run-state", expected_task_id="task-001")
 
 
-def test_run_route_rejects_schema_invalid_existing_run_state(tmp_path: Path) -> None:
+def test_run_route_rejects_schema_invalid_existing_run_state(
+    tmp_path: Path,
+    make_task_dir: Callable[[Path], Path],
+    write_json: Callable[[Path, dict], None],
+) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_json(
+    task_dir = make_task_dir(tmp_path)
+    write_json(
         task_dir / "run-state.json",
         {
             "schema_version": "0.1",
@@ -86,7 +48,7 @@ def test_run_route_rejects_schema_invalid_existing_run_state(tmp_path: Path) -> 
             "quality_review_approved": False,
         },
     )
-    _write_json(
+    write_json(
         task_dir / "review-report.json",
         {
             "schema_version": "0.1",
@@ -103,10 +65,14 @@ def test_run_route_rejects_schema_invalid_existing_run_state(tmp_path: Path) -> 
         run_route(task_dir=task_dir, policy=policy, route_name="small")
 
 
-def test_run_route_rejects_schema_invalid_review_report(tmp_path: Path) -> None:
+def test_run_route_rejects_schema_invalid_review_report(
+    tmp_path: Path,
+    make_task_dir: Callable[[Path], Path],
+    write_json: Callable[[Path, dict], None],
+) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_json(
+    task_dir = make_task_dir(tmp_path)
+    write_json(
         task_dir / "review-report.json",
         {
             "schema_version": "0.1",
@@ -121,10 +87,14 @@ def test_run_route_rejects_schema_invalid_review_report(tmp_path: Path) -> None:
         run_route(task_dir=task_dir, policy=policy, route_name="small")
 
 
-def test_run_route_rejects_mismatched_review_report_task_id(tmp_path: Path) -> None:
+def test_run_route_rejects_mismatched_review_report_task_id(
+    tmp_path: Path,
+    make_task_dir: Callable[[Path], Path],
+    write_json: Callable[[Path, dict], None],
+) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_json(
+    task_dir = make_task_dir(tmp_path)
+    write_json(
         task_dir / "review-report.json",
         {
             "schema_version": "0.1",
@@ -141,11 +111,14 @@ def test_run_route_rejects_mismatched_review_report_task_id(tmp_path: Path) -> N
         run_route(task_dir=task_dir, policy=policy, route_name="small")
 
 
-def test_run_route_rejects_mismatched_eval_record_task_id(tmp_path: Path) -> None:
+def test_run_route_rejects_mismatched_eval_record_task_id(
+    tmp_path: Path,
+    write_json: Callable[[Path, dict], None],
+) -> None:
     policy = load_runtime_policy(ROOT)
     task_dir = tmp_path / "large-task"
     task_dir.mkdir()
-    _write_json(
+    write_json(
         task_dir / "brief.json",
         {
             "schema_version": "0.1",
@@ -158,7 +131,7 @@ def test_run_route_rejects_mismatched_eval_record_task_id(tmp_path: Path) -> Non
             "risk_level": "high",
         },
     )
-    _write_json(
+    write_json(
         task_dir / "plan.json",
         {
             "schema_version": "0.1",
@@ -173,7 +146,7 @@ def test_run_route_rejects_mismatched_eval_record_task_id(tmp_path: Path) -> Non
             ],
         },
     )
-    _write_json(
+    write_json(
         task_dir / "plan-ledger.json",
         {
             "schema_version": "0.1",
@@ -195,7 +168,7 @@ def test_run_route_rejects_mismatched_eval_record_task_id(tmp_path: Path) -> Non
             ],
         },
     )
-    _write_json(
+    write_json(
         task_dir / "review-report-spec.json",
         {
             "schema_version": "0.1",
@@ -207,7 +180,7 @@ def test_run_route_rejects_mismatched_eval_record_task_id(tmp_path: Path) -> Non
             "next_action": "quality-review로 진행",
         },
     )
-    _write_json(
+    write_json(
         task_dir / "review-report-quality.json",
         {
             "schema_version": "0.1",
@@ -219,7 +192,7 @@ def test_run_route_rejects_mismatched_eval_record_task_id(tmp_path: Path) -> Non
             "next_action": "finalize 가능",
         },
     )
-    _write_json(
+    write_json(
         task_dir / "eval-record.json",
         {
             "schema_version": "0.1",
@@ -234,9 +207,13 @@ def test_run_route_rejects_mismatched_eval_record_task_id(tmp_path: Path) -> Non
         run_route(task_dir=task_dir, policy=policy, route_name="large_high_risk")
 
 
-def test_retry_stage_rejects_mismatched_decision_log_task_id(tmp_path: Path) -> None:
-    task_dir = _make_task_dir(tmp_path)
-    _write_json(
+def test_retry_stage_rejects_mismatched_decision_log_task_id(
+    tmp_path: Path,
+    make_task_dir: Callable[[Path], Path],
+    write_json: Callable[[Path, dict], None],
+) -> None:
+    task_dir = make_task_dir(tmp_path)
+    write_json(
         task_dir / "decision-log.json",
         {
             "schema_version": "0.1",
@@ -249,10 +226,15 @@ def test_retry_stage_rejects_mismatched_decision_log_task_id(tmp_path: Path) -> 
         retry_stage(task_dir=task_dir, stage_name="execute")
 
 
-def test_run_route_migrates_legacy_decision_log_timestamps(tmp_path: Path) -> None:
+def test_run_route_migrates_legacy_decision_log_timestamps(
+    tmp_path: Path,
+    make_task_dir: Callable[[Path], Path],
+    write_json: Callable[[Path, dict], None],
+    assert_schema_valid: Callable[[str, dict], None],
+) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_json(
+    task_dir = make_task_dir(tmp_path)
+    write_json(
         task_dir / "decision-log.json",
         {
             "schema_version": "0.1",
@@ -269,7 +251,7 @@ def test_run_route_migrates_legacy_decision_log_timestamps(tmp_path: Path) -> No
             ],
         },
     )
-    _write_json(
+    write_json(
         task_dir / "review-report.json",
         {
             "schema_version": "0.1",
@@ -286,5 +268,5 @@ def test_run_route_migrates_legacy_decision_log_timestamps(tmp_path: Path) -> No
 
     assert result["status"] == "completed"
     decision_log = json.loads((task_dir / "decision-log.json").read_text(encoding="utf-8"))
-    _assert_schema_valid("decision-log", decision_log)
+    assert_schema_valid("decision-log", decision_log)
     assert decision_log["entries"][0]["timestamp"] == "1970-01-01T00:00:01Z"

--- a/tests/runtime/test_checkpoint_resume.py
+++ b/tests/runtime/test_checkpoint_resume.py
@@ -1,8 +1,8 @@
 import json
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
-from jsonschema import Draft202012Validator
 
 from forgeflow_runtime.orchestrator import (
     RuntimeViolation,
@@ -17,110 +17,23 @@ from forgeflow_runtime.orchestrator import (
 ROOT = Path(__file__).resolve().parents[2]
 
 
-def _write_json(path: Path, payload: dict) -> None:
-    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-
-
-def _load_schema(name: str) -> dict:
-    return json.loads((ROOT / "schemas" / f"{name}.schema.json").read_text(encoding="utf-8"))
-
-
-def _assert_schema_valid(name: str, payload: dict) -> None:
-    errors = sorted(Draft202012Validator(_load_schema(name)).iter_errors(payload), key=lambda err: list(err.path))
-    assert not errors, [f"{list(err.path)}: {err.message}" for err in errors]
-
-
-def _make_task_dir(tmp_path: Path) -> Path:
-    task_dir = tmp_path / "task"
-    task_dir.mkdir()
-    _write_json(
-        task_dir / "brief.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "objective": "Run a small route",
-            "in_scope": ["runtime"],
-            "out_of_scope": [],
-            "constraints": ["local only"],
-            "acceptance_criteria": ["route works"],
-            "risk_level": "low",
-        },
-    )
-    _write_json(
-        task_dir / "run-state.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "current_stage": "clarify",
-            "status": "in_progress",
-            "completed_gates": ["clarification_complete"],
-            "failed_gates": [],
-            "retries": {},
-            "current_task_id": "",
-            "spec_review_approved": False,
-            "quality_review_approved": False,
-        },
-    )
-    return task_dir
-
-
-def _write_medium_plan_artifacts(task_dir: Path, *, route_name: str = "medium") -> None:
-    _write_json(
-        task_dir / "plan.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "steps": [
-                {
-                    "id": "step-1",
-                    "objective": "update workflow docs",
-                    "dependencies": [],
-                    "expected_output": "workflow docs reflect medium route behavior",
-                    "verification": "pytest tests/runtime/test_checkpoint_resume.py -q",
-                    "rollback_note": "remove incomplete workflow edits if validation fails",
-                }
-            ],
-        },
-    )
-    _write_json(
-        task_dir / "plan-ledger.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "route": route_name,
-            "completed_stages": [],
-            "completed_gates": [],
-            "retries": {},
-            "current_task_id": "task-1",
-            "tasks": [
-                {
-                    "id": "task-1",
-                    "title": "update workflow docs",
-                    "depends_on": [],
-                    "files": ["docs/workflow.md"],
-                    "parallel_safe": False,
-                    "status": "in_progress",
-                    "required_gates": ["machine", "validator"],
-                    "evidence_refs": [],
-                    "attempt_count": 0,
-                }
-            ],
-        },
-    )
-
-
-def test_run_route_rejects_medium_plan_ledger_out_of_order_completed_stages(tmp_path: Path) -> None:
+def test_run_route_rejects_medium_plan_ledger_out_of_order_completed_stages(
+    tmp_path: Path,
+    medium_plan_artifacts: Callable[..., None],
+    write_json: Callable[[Path, dict], None],
+    make_task_dir: Callable[[Path], Path],
+) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_medium_plan_artifacts(task_dir, route_name="medium")
+    task_dir = make_task_dir(tmp_path)
+    medium_plan_artifacts(task_dir, route_name="medium")
     run_state = json.loads((task_dir / "run-state.json").read_text(encoding="utf-8"))
     run_state["current_stage"] = "execute"
-    _write_json(task_dir / "run-state.json", run_state)
+    write_json(task_dir / "run-state.json", run_state)
     plan_ledger = json.loads((task_dir / "plan-ledger.json").read_text(encoding="utf-8"))
     plan_ledger["completed_stages"] = ["clarify", "plan", "quality-review"]
     plan_ledger["completed_gates"] = ["clarification_complete", "plan_executable"]
-    _write_json(task_dir / "plan-ledger.json", plan_ledger)
-    _write_json(
+    write_json(task_dir / "plan-ledger.json", plan_ledger)
+    write_json(
         task_dir / "review-report.json",
         {
             "schema_version": "0.1",
@@ -137,10 +50,15 @@ def test_run_route_rejects_medium_plan_ledger_out_of_order_completed_stages(tmp_
         run_route(task_dir=task_dir, policy=policy, route_name="medium")
 
 
-def test_run_route_resumes_from_existing_checkpoint(tmp_path: Path) -> None:
+def test_run_route_resumes_from_existing_checkpoint(
+    tmp_path: Path,
+    assert_schema_valid: Callable[[str, dict], None],
+    write_json: Callable[[Path, dict], None],
+    make_task_dir: Callable[[Path], Path],
+) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_json(
+    task_dir = make_task_dir(tmp_path)
+    write_json(
         task_dir / "run-state.json",
         {
             "schema_version": "0.1",
@@ -155,7 +73,7 @@ def test_run_route_resumes_from_existing_checkpoint(tmp_path: Path) -> None:
             "quality_review_approved": False,
         },
     )
-    _write_json(
+    write_json(
         task_dir / "decision-log.json",
         {
             "schema_version": "0.1",
@@ -172,7 +90,7 @@ def test_run_route_resumes_from_existing_checkpoint(tmp_path: Path) -> None:
             ],
         },
     )
-    _write_json(
+    write_json(
         task_dir / "review-report.json",
         {
             "schema_version": "0.1",
@@ -184,7 +102,7 @@ def test_run_route_resumes_from_existing_checkpoint(tmp_path: Path) -> None:
             "next_action": "finalize 가능",
         },
     )
-    _write_json(
+    write_json(
         task_dir / "checkpoint.json",
         {
             "schema_version": "0.1",
@@ -221,7 +139,7 @@ def test_run_route_resumes_from_existing_checkpoint(tmp_path: Path) -> None:
         "stage entered: finalize",
     ]
     checkpoint = json.loads((task_dir / "checkpoint.json").read_text(encoding="utf-8"))
-    _assert_schema_valid("checkpoint", checkpoint)
+    assert_schema_valid("checkpoint", checkpoint)
     assert checkpoint["current_stage"] == "finalize"
     assert checkpoint["run_state_ref"] == "run-state.json"
     assert checkpoint["latest_review_ref"] == "review-report.json"
@@ -229,10 +147,14 @@ def test_run_route_resumes_from_existing_checkpoint(tmp_path: Path) -> None:
     assert checkpoint["open_blockers"] == []
 
 
-def test_run_route_rejects_mismatched_checkpoint_route(tmp_path: Path) -> None:
+def test_run_route_rejects_mismatched_checkpoint_route(
+    tmp_path: Path,
+    write_json: Callable[[Path, dict], None],
+    make_task_dir: Callable[[Path], Path],
+) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_json(
+    task_dir = make_task_dir(tmp_path)
+    write_json(
         task_dir / "checkpoint.json",
         {
             "schema_version": "0.1",
@@ -247,7 +169,7 @@ def test_run_route_rejects_mismatched_checkpoint_route(tmp_path: Path) -> None:
             "updated_at": "2026-04-22T00:05:00Z"
         },
     )
-    _write_json(
+    write_json(
         task_dir / "review-report.json",
         {
             "schema_version": "0.1",
@@ -264,10 +186,14 @@ def test_run_route_rejects_mismatched_checkpoint_route(tmp_path: Path) -> None:
         run_route(task_dir=task_dir, policy=policy, route_name="small")
 
 
-def test_run_route_rejects_checkpoint_gate_drift(tmp_path: Path) -> None:
+def test_run_route_rejects_checkpoint_gate_drift(
+    tmp_path: Path,
+    write_json: Callable[[Path, dict], None],
+    make_task_dir: Callable[[Path], Path],
+) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_json(
+    task_dir = make_task_dir(tmp_path)
+    write_json(
         task_dir / "run-state.json",
         {
             "schema_version": "0.1",
@@ -282,7 +208,7 @@ def test_run_route_rejects_checkpoint_gate_drift(tmp_path: Path) -> None:
             "quality_review_approved": False,
         },
     )
-    _write_json(
+    write_json(
         task_dir / "review-report.json",
         {
             "schema_version": "0.1",
@@ -299,10 +225,14 @@ def test_run_route_rejects_checkpoint_gate_drift(tmp_path: Path) -> None:
         run_route(task_dir=task_dir, policy=policy, route_name="small")
 
 
-def test_run_route_rejects_future_gate_checkpoint_drift(tmp_path: Path) -> None:
+def test_run_route_rejects_future_gate_checkpoint_drift(
+    tmp_path: Path,
+    write_json: Callable[[Path, dict], None],
+    make_task_dir: Callable[[Path], Path],
+) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_json(
+    task_dir = make_task_dir(tmp_path)
+    write_json(
         task_dir / "run-state.json",
         {
             "schema_version": "0.1",
@@ -317,7 +247,7 @@ def test_run_route_rejects_future_gate_checkpoint_drift(tmp_path: Path) -> None:
             "quality_review_approved": False,
         },
     )
-    _write_json(
+    write_json(
         task_dir / "review-report.json",
         {
             "schema_version": "0.1",
@@ -334,10 +264,14 @@ def test_run_route_rejects_future_gate_checkpoint_drift(tmp_path: Path) -> None:
         run_route(task_dir=task_dir, policy=policy, route_name="small")
 
 
-def test_run_route_rejects_incomplete_completed_checkpoint(tmp_path: Path) -> None:
+def test_run_route_rejects_incomplete_completed_checkpoint(
+    tmp_path: Path,
+    write_json: Callable[[Path, dict], None],
+    make_task_dir: Callable[[Path], Path],
+) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_json(
+    task_dir = make_task_dir(tmp_path)
+    write_json(
         task_dir / "run-state.json",
         {
             "schema_version": "0.1",
@@ -353,7 +287,7 @@ def test_run_route_rejects_incomplete_completed_checkpoint(tmp_path: Path) -> No
             "final_status": "success",
         },
     )
-    _write_json(
+    write_json(
         task_dir / "review-report.json",
         {
             "schema_version": "0.1",
@@ -370,23 +304,32 @@ def test_run_route_rejects_incomplete_completed_checkpoint(tmp_path: Path) -> No
         run_route(task_dir=task_dir, policy=policy, route_name="small")
 
 
-def test_advance_rejects_mismatched_run_state_stage(tmp_path: Path) -> None:
+def test_advance_rejects_mismatched_run_state_stage(
+    tmp_path: Path,
+    write_json: Callable[[Path, dict], None],
+    make_task_dir: Callable[[Path], Path],
+) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
+    task_dir = make_task_dir(tmp_path)
 
     run_state = json.loads((task_dir / "run-state.json").read_text(encoding="utf-8"))
     run_state["current_stage"] = "execute"
-    _write_json(task_dir / "run-state.json", run_state)
+    write_json(task_dir / "run-state.json", run_state)
 
     with pytest.raises(RuntimeViolation, match="requested current_stage clarify does not match persisted run-state stage execute"):
         advance_to_next_stage(task_dir=task_dir, policy=policy, route_name="small", current_stage="clarify")
 
 
-def test_resume_rejects_medium_session_state_with_wrong_plan_ledger_ref(tmp_path: Path) -> None:
+def test_resume_rejects_medium_session_state_with_wrong_plan_ledger_ref(
+    tmp_path: Path,
+    medium_plan_artifacts: Callable[..., None],
+    write_json: Callable[[Path, dict], None],
+    make_task_dir: Callable[[Path], Path],
+) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_medium_plan_artifacts(task_dir, route_name="medium")
-    _write_json(
+    task_dir = make_task_dir(tmp_path)
+    medium_plan_artifacts(task_dir, route_name="medium")
+    write_json(
         task_dir / "checkpoint.json",
         {
             "schema_version": "0.1",
@@ -401,7 +344,7 @@ def test_resume_rejects_medium_session_state_with_wrong_plan_ledger_ref(tmp_path
             "updated_at": "2026-04-22T00:05:00Z",
         },
     )
-    _write_json(
+    write_json(
         task_dir / "session-state.json",
         {
             "schema_version": "0.1",
@@ -421,10 +364,14 @@ def test_resume_rejects_medium_session_state_with_wrong_plan_ledger_ref(tmp_path
         resume_task(task_dir=task_dir, policy=policy, route_name="medium")
 
 
-def test_resume_rejects_stale_session_state_latest_review_ref(tmp_path: Path) -> None:
+def test_resume_rejects_stale_session_state_latest_review_ref(
+    tmp_path: Path,
+    write_json: Callable[[Path, dict], None],
+    make_task_dir: Callable[[Path], Path],
+) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_json(
+    task_dir = make_task_dir(tmp_path)
+    write_json(
         task_dir / "review-report-spec.json",
         {
             "schema_version": "0.1",
@@ -436,7 +383,7 @@ def test_resume_rejects_stale_session_state_latest_review_ref(tmp_path: Path) ->
             "next_action": "quality-review로 진행",
         },
     )
-    _write_json(
+    write_json(
         task_dir / "review-report-quality.json",
         {
             "schema_version": "0.1",
@@ -448,7 +395,7 @@ def test_resume_rejects_stale_session_state_latest_review_ref(tmp_path: Path) ->
             "next_action": "finalize 가능",
         },
     )
-    _write_json(
+    write_json(
         task_dir / "checkpoint.json",
         {
             "schema_version": "0.1",
@@ -464,7 +411,7 @@ def test_resume_rejects_stale_session_state_latest_review_ref(tmp_path: Path) ->
             "updated_at": "2026-04-22T00:05:00Z",
         },
     )
-    _write_json(
+    write_json(
         task_dir / "session-state.json",
         {
             "schema_version": "0.1",
@@ -485,10 +432,14 @@ def test_resume_rejects_stale_session_state_latest_review_ref(tmp_path: Path) ->
         resume_task(task_dir=task_dir, policy=policy, route_name="small")
 
 
-def test_status_rejects_session_state_route_drift(tmp_path: Path) -> None:
+def test_status_rejects_session_state_route_drift(
+    tmp_path: Path,
+    write_json: Callable[[Path, dict], None],
+    make_task_dir: Callable[[Path], Path],
+) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_json(
+    task_dir = make_task_dir(tmp_path)
+    write_json(
         task_dir / "checkpoint.json",
         {
             "schema_version": "0.1",
@@ -503,7 +454,7 @@ def test_status_rejects_session_state_route_drift(tmp_path: Path) -> None:
             "updated_at": "2026-04-22T00:05:00Z",
         },
     )
-    _write_json(
+    write_json(
         task_dir / "session-state.json",
         {
             "schema_version": "0.1",
@@ -523,10 +474,14 @@ def test_status_rejects_session_state_route_drift(tmp_path: Path) -> None:
         status_summary(task_dir=task_dir, policy=policy, route_name="small")
 
 
-def test_status_rejects_session_state_stage_drift(tmp_path: Path) -> None:
+def test_status_rejects_session_state_stage_drift(
+    tmp_path: Path,
+    write_json: Callable[[Path, dict], None],
+    make_task_dir: Callable[[Path], Path],
+) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_json(
+    task_dir = make_task_dir(tmp_path)
+    write_json(
         task_dir / "checkpoint.json",
         {
             "schema_version": "0.1",
@@ -541,7 +496,7 @@ def test_status_rejects_session_state_stage_drift(tmp_path: Path) -> None:
             "updated_at": "2026-04-22T00:05:00Z",
         },
     )
-    _write_json(
+    write_json(
         task_dir / "session-state.json",
         {
             "schema_version": "0.1",
@@ -561,10 +516,14 @@ def test_status_rejects_session_state_stage_drift(tmp_path: Path) -> None:
         status_summary(task_dir=task_dir, policy=policy, route_name="small")
 
 
-def test_status_rejects_session_state_latest_review_ref_that_escapes_task_dir(tmp_path: Path) -> None:
+def test_status_rejects_session_state_latest_review_ref_that_escapes_task_dir(
+    tmp_path: Path,
+    write_json: Callable[[Path, dict], None],
+    make_task_dir: Callable[[Path], Path],
+) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_json(
+    task_dir = make_task_dir(tmp_path)
+    write_json(
         task_dir / "checkpoint.json",
         {
             "schema_version": "0.1",
@@ -579,7 +538,7 @@ def test_status_rejects_session_state_latest_review_ref_that_escapes_task_dir(tm
             "updated_at": "2026-04-22T00:05:00Z",
         },
     )
-    _write_json(
+    write_json(
         task_dir / "session-state.json",
         {
             "schema_version": "0.1",

--- a/tests/runtime/test_fixture_contract.py
+++ b/tests/runtime/test_fixture_contract.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+from typing import Callable
+
+
+def test_make_task_dir_fixture_writes_basic_runtime_artifacts(make_task_dir: Callable[[Path], Path], tmp_path: Path) -> None:
+    task_dir = make_task_dir(tmp_path)
+
+    assert (task_dir / "brief.json").exists()
+    assert (task_dir / "run-state.json").exists()

--- a/tests/runtime/test_operator_routing.py
+++ b/tests/runtime/test_operator_routing.py
@@ -1,4 +1,4 @@
-import json
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -7,24 +7,29 @@ from forgeflow_runtime.operator_routing import effective_route, role_for_stage
 from forgeflow_runtime.orchestrator import RuntimeViolation
 
 
-def _write_json(path: Path, data: dict) -> None:
-    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
-
-
-def test_effective_route_uses_explicit_route_before_artifacts(tmp_path: Path) -> None:
-    _write_json(tmp_path / "checkpoint.json", {"route": "large_high_risk"})
+def test_effective_route_uses_explicit_route_before_artifacts(
+    tmp_path: Path,
+    write_json: Callable[[Path, dict], None],
+) -> None:
+    write_json(tmp_path / "checkpoint.json", {"route": "large_high_risk"})
 
     assert effective_route(task_dir=tmp_path, explicit_route="small", min_route=None) == "small"
 
 
-def test_effective_route_promotes_auto_detected_route_to_minimum(tmp_path: Path) -> None:
-    _write_json(tmp_path / "brief.json", {"risk_level": "low"})
+def test_effective_route_promotes_auto_detected_route_to_minimum(
+    tmp_path: Path,
+    write_json: Callable[[Path, dict], None],
+) -> None:
+    write_json(tmp_path / "brief.json", {"risk_level": "low"})
 
     assert effective_route(task_dir=tmp_path, explicit_route=None, min_route="medium") == "medium"
 
 
-def test_effective_route_reads_existing_runtime_artifact_route(tmp_path: Path) -> None:
-    _write_json(tmp_path / "session-state.json", {"route": "large_high_risk"})
+def test_effective_route_reads_existing_runtime_artifact_route(
+    tmp_path: Path,
+    write_json: Callable[[Path, dict], None],
+) -> None:
+    write_json(tmp_path / "session-state.json", {"route": "large_high_risk"})
 
     assert effective_route(task_dir=tmp_path, explicit_route=None, min_route=None) == "large_high_risk"
 

--- a/tests/runtime/test_plan_ledger.py
+++ b/tests/runtime/test_plan_ledger.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -15,48 +16,12 @@ from forgeflow_runtime.orchestrator import (
 ROOT = Path(__file__).resolve().parents[2]
 
 
-def _write_json(path: Path, payload: dict) -> None:
-    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-
-
-def _make_task_dir(tmp_path: Path) -> Path:
-    task_dir = tmp_path / "task"
-    task_dir.mkdir()
-    _write_json(
-        task_dir / "brief.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "objective": "Run a small route",
-            "in_scope": ["runtime"],
-            "out_of_scope": [],
-            "constraints": ["local only"],
-            "acceptance_criteria": ["route works"],
-            "risk_level": "low",
-        },
-    )
-    _write_json(
-        task_dir / "run-state.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "current_stage": "clarify",
-            "status": "in_progress",
-            "completed_gates": ["clarification_complete"],
-            "failed_gates": [],
-            "retries": {},
-            "current_task_id": "",
-            "spec_review_approved": False,
-            "quality_review_approved": False,
-        },
-    )
-    return task_dir
-
-
-def test_run_route_requires_plan_ledger_for_medium_route(tmp_path: Path) -> None:
+def test_run_route_requires_plan_ledger_for_medium_route(
+    make_task_dir: Callable[[Path], Path], write_json: Callable[[Path, dict], None], tmp_path: Path
+) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_json(
+    task_dir = make_task_dir(tmp_path)
+    write_json(
         task_dir / "plan.json",
         {
             "schema_version": "0.1",
@@ -78,10 +43,12 @@ def test_run_route_requires_plan_ledger_for_medium_route(tmp_path: Path) -> None
         run_route(task_dir=task_dir, policy=policy, route_name="medium")
 
 
-def test_advance_requires_plan_ledger_for_medium_route(tmp_path: Path) -> None:
+def test_advance_requires_plan_ledger_for_medium_route(
+    make_task_dir: Callable[[Path], Path], write_json: Callable[[Path, dict], None], tmp_path: Path
+) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_json(
+    task_dir = make_task_dir(tmp_path)
+    write_json(
         task_dir / "plan.json",
         {
             "schema_version": "0.1",
@@ -100,62 +67,22 @@ def test_advance_requires_plan_ledger_for_medium_route(tmp_path: Path) -> None:
     )
     run_state = json.loads((task_dir / "run-state.json").read_text(encoding="utf-8"))
     run_state["current_stage"] = "plan"
-    _write_json(task_dir / "run-state.json", run_state)
+    write_json(task_dir / "run-state.json", run_state)
 
     with pytest.raises(RuntimeViolation, match="medium route requires plan-ledger.json"):
         advance_to_next_stage(task_dir=task_dir, policy=policy, route_name="medium", current_stage="plan")
 
 
-def _write_medium_plan_artifacts(task_dir: Path, *, route_name: str = "medium") -> None:
-    _write_json(
-        task_dir / "plan.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "steps": [
-                {
-                    "id": "step-1",
-                    "objective": "update workflow docs",
-                    "dependencies": [],
-                    "expected_output": "workflow docs reflect medium route behavior",
-                    "verification": "pytest tests/test_runtime_orchestrator.py -q",
-                    "rollback_note": "remove incomplete workflow edits if validation fails",
-                }
-            ],
-        },
-    )
-    _write_json(
-        task_dir / "plan-ledger.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "route": route_name,
-            "completed_stages": [],
-            "completed_gates": [],
-            "retries": {},
-            "current_task_id": "task-1",
-            "tasks": [
-                {
-                    "id": "task-1",
-                    "title": "update workflow docs",
-                    "depends_on": [],
-                    "files": ["docs/workflow.md"],
-                    "parallel_safe": False,
-                    "status": "in_progress",
-                    "required_gates": ["machine", "validator"],
-                    "evidence_refs": [],
-                    "attempt_count": 0,
-                }
-            ],
-        },
-    )
-
-
-def test_run_route_syncs_current_task_from_plan_ledger(tmp_path: Path) -> None:
+def test_run_route_syncs_current_task_from_plan_ledger(
+    make_task_dir: Callable[[Path], Path],
+    medium_plan_artifacts: Callable[..., None],
+    write_json: Callable[[Path, dict], None],
+    tmp_path: Path,
+) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_medium_plan_artifacts(task_dir)
-    _write_json(
+    task_dir = make_task_dir(tmp_path)
+    medium_plan_artifacts(task_dir)
+    write_json(
         task_dir / "review-report.json",
         {
             "schema_version": "0.1",
@@ -191,9 +118,11 @@ def test_run_route_syncs_current_task_from_plan_ledger(tmp_path: Path) -> None:
     assert persisted_run_state["completed_gates"] == ["clarification_complete"]
 
 
-def test_retry_stage_updates_plan_ledger_attempts(tmp_path: Path) -> None:
-    task_dir = _make_task_dir(tmp_path)
-    _write_medium_plan_artifacts(task_dir)
+def test_retry_stage_updates_plan_ledger_attempts(
+    make_task_dir: Callable[[Path], Path], medium_plan_artifacts: Callable[..., None], tmp_path: Path
+) -> None:
+    task_dir = make_task_dir(tmp_path)
+    medium_plan_artifacts(task_dir)
 
     result = retry_stage(task_dir=task_dir, stage_name="execute", max_retries=2)
 
@@ -206,13 +135,18 @@ def test_retry_stage_updates_plan_ledger_attempts(tmp_path: Path) -> None:
     assert persisted_run_state["retries"] == {}
 
 
-def test_advance_updates_plan_ledger_gate_evidence(tmp_path: Path) -> None:
+def test_advance_updates_plan_ledger_gate_evidence(
+    make_task_dir: Callable[[Path], Path],
+    medium_plan_artifacts: Callable[..., None],
+    write_json: Callable[[Path, dict], None],
+    tmp_path: Path,
+) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_medium_plan_artifacts(task_dir)
+    task_dir = make_task_dir(tmp_path)
+    medium_plan_artifacts(task_dir)
     run_state = json.loads((task_dir / "run-state.json").read_text(encoding="utf-8"))
     run_state["current_stage"] = "plan"
-    _write_json(task_dir / "run-state.json", run_state)
+    write_json(task_dir / "run-state.json", run_state)
 
     result = advance_to_next_stage(task_dir=task_dir, policy=policy, route_name="medium", current_stage="plan")
 
@@ -224,4 +158,3 @@ def test_advance_updates_plan_ledger_gate_evidence(tmp_path: Path) -> None:
     assert persisted_plan_ledger["completed_gates"] == ["plan_executable"]
     assert "run-state.json#gate:plan_executable" in persisted_plan_ledger["tasks"][0]["evidence_refs"]
     assert persisted_run_state["completed_gates"] == ["clarification_complete"]
-

--- a/tests/runtime/test_retry_stage.py
+++ b/tests/runtime/test_retry_stage.py
@@ -1,89 +1,20 @@
 import json
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
-from jsonschema import Draft202012Validator
 
 from forgeflow_runtime.orchestrator import RuntimeViolation, retry_stage
 
 
-ROOT = Path(__file__).resolve().parents[2]
-
-
-def _write_json(path: Path, payload: dict) -> None:
-    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-
-
-def _load_schema(name: str) -> dict:
-    return json.loads((ROOT / "schemas" / f"{name}.schema.json").read_text(encoding="utf-8"))
-
-
-def _assert_schema_valid(name: str, payload: dict) -> None:
-    errors = sorted(Draft202012Validator(_load_schema(name)).iter_errors(payload), key=lambda err: list(err.path))
-    assert not errors, [f"{list(err.path)}: {err.message}" for err in errors]
-
-
-def _make_task_dir(tmp_path: Path) -> Path:
-    task_dir = tmp_path / "task"
-    task_dir.mkdir()
-    _write_json(
-        task_dir / "brief.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "objective": "Run a small route",
-            "in_scope": ["runtime"],
-            "out_of_scope": [],
-            "constraints": ["local only"],
-            "acceptance_criteria": ["route works"],
-            "risk_level": "low",
-        },
-    )
-    _write_json(
-        task_dir / "run-state.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "current_stage": "clarify",
-            "status": "in_progress",
-            "completed_gates": ["clarification_complete"],
-            "failed_gates": [],
-            "retries": {},
-            "current_task_id": "",
-            "spec_review_approved": False,
-            "quality_review_approved": False,
-        },
-    )
-    return task_dir
-
-
-def _write_medium_plan_ledger(task_dir: Path) -> None:
-    _write_json(
-        task_dir / "plan-ledger.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "route": "medium",
-            "current_task_id": "task-1",
-            "tasks": [
-                {
-                    "id": "task-1",
-                    "title": "execute bounded refactor",
-                    "depends_on": [],
-                    "files": ["run-state.json"],
-                    "parallel_safe": False,
-                    "status": "in_progress",
-                    "required_gates": ["machine", "validator"],
-                    "evidence_refs": [],
-                    "attempt_count": 0,
-                }
-            ],
-        },
-    )
-
-
-def _write_retry_checkpoint(task_dir: Path, *, route: str = "medium", stage: str = "execute") -> None:
-    _write_json(
+def _write_retry_checkpoint(
+    task_dir: Path,
+    write_json: Callable[[Path, dict], None],
+    *,
+    route: str = "medium",
+    stage: str = "execute",
+) -> None:
+    write_json(
         task_dir / "checkpoint.json",
         {
             "schema_version": "0.1",
@@ -101,8 +32,12 @@ def _write_retry_checkpoint(task_dir: Path, *, route: str = "medium", stage: str
     )
 
 
-def test_retry_is_bounded(tmp_path: Path) -> None:
-    task_dir = _make_task_dir(tmp_path)
+def test_retry_is_bounded(
+    tmp_path: Path,
+    make_task_dir: Callable[[Path], Path],
+    assert_schema_valid: Callable[[str, dict], None],
+) -> None:
+    task_dir = make_task_dir(tmp_path)
 
     first = retry_stage(task_dir=task_dir, stage_name="execute", max_retries=2)
     second = retry_stage(task_dir=task_dir, stage_name="execute", max_retries=2)
@@ -110,7 +45,7 @@ def test_retry_is_bounded(tmp_path: Path) -> None:
     assert first["retries"]["execute"] == 1
     assert second["retries"]["execute"] == 2
     checkpoint = json.loads((task_dir / "checkpoint.json").read_text(encoding="utf-8"))
-    _assert_schema_valid("checkpoint", checkpoint)
+    assert_schema_valid("checkpoint", checkpoint)
     assert checkpoint["current_stage"] == "execute"
     assert checkpoint["run_state_ref"] == "run-state.json"
     assert checkpoint["next_action"] == "Resume at quality-review after reloading canonical artifacts."
@@ -119,34 +54,49 @@ def test_retry_is_bounded(tmp_path: Path) -> None:
         retry_stage(task_dir=task_dir, stage_name="execute", max_retries=2)
 
 
-def test_retry_stage_preserves_medium_route_checkpoint(tmp_path: Path) -> None:
-    task_dir = _make_task_dir(tmp_path)
-    _write_medium_plan_ledger(task_dir)
-    _write_retry_checkpoint(task_dir)
+def test_retry_stage_preserves_medium_route_checkpoint(
+    tmp_path: Path,
+    make_task_dir: Callable[[Path], Path],
+    medium_plan_artifacts: Callable[..., None],
+    write_json: Callable[[Path, dict], None],
+    assert_schema_valid: Callable[[str, dict], None],
+) -> None:
+    task_dir = make_task_dir(tmp_path)
+    medium_plan_artifacts(task_dir)
+    _write_retry_checkpoint(task_dir, write_json)
 
     state = retry_stage(task_dir=task_dir, stage_name="execute", max_retries=2)
 
     assert state["current_task_id"] == "task-1"
     checkpoint = json.loads((task_dir / "checkpoint.json").read_text(encoding="utf-8"))
-    _assert_schema_valid("checkpoint", checkpoint)
+    assert_schema_valid("checkpoint", checkpoint)
     assert checkpoint["route"] == "medium"
     assert checkpoint["plan_ledger_ref"] == "plan-ledger.json"
     assert checkpoint["current_task_id"] == "task-1"
     assert checkpoint["next_action"] == "Resume at quality-review after reloading canonical artifacts."
 
 
-def test_retry_stage_rejects_checkpoint_route_drift_against_plan_ledger(tmp_path: Path) -> None:
-    task_dir = _make_task_dir(tmp_path)
-    _write_medium_plan_ledger(task_dir)
-    _write_retry_checkpoint(task_dir, route="small")
+def test_retry_stage_rejects_checkpoint_route_drift_against_plan_ledger(
+    tmp_path: Path,
+    make_task_dir: Callable[[Path], Path],
+    medium_plan_artifacts: Callable[..., None],
+    write_json: Callable[[Path, dict], None],
+) -> None:
+    task_dir = make_task_dir(tmp_path)
+    medium_plan_artifacts(task_dir)
+    _write_retry_checkpoint(task_dir, write_json, route="small")
 
     with pytest.raises(RuntimeViolation, match="checkpoint.json route small does not match canonical route medium"):
         retry_stage(task_dir=task_dir, stage_name="execute", max_retries=2)
 
 
-def test_retry_stage_rejects_stage_outside_inferred_route(tmp_path: Path) -> None:
-    task_dir = _make_task_dir(tmp_path)
-    _write_json(
+def test_retry_stage_rejects_stage_outside_inferred_route(
+    tmp_path: Path,
+    make_task_dir: Callable[[Path], Path],
+    write_json: Callable[[Path, dict], None],
+) -> None:
+    task_dir = make_task_dir(tmp_path)
+    write_json(
         task_dir / "run-state.json",
         {
             "schema_version": "0.1",
@@ -161,7 +111,7 @@ def test_retry_stage_rejects_stage_outside_inferred_route(tmp_path: Path) -> Non
             "quality_review_approved": False,
         },
     )
-    _write_json(
+    write_json(
         task_dir / "checkpoint.json",
         {
             "schema_version": "0.1",

--- a/tests/runtime/test_review_gates.py
+++ b/tests/runtime/test_review_gates.py
@@ -1,4 +1,5 @@
 import json
+from typing import Callable
 from pathlib import Path
 
 import pytest
@@ -9,51 +10,13 @@ from forgeflow_runtime.orchestrator import RuntimeViolation, advance_to_next_sta
 ROOT = Path(__file__).resolve().parents[2]
 
 
-def _write_json(path: Path, payload: dict) -> None:
-    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-
-
-def _make_task_dir(tmp_path: Path) -> Path:
-    task_dir = tmp_path / "task"
-    task_dir.mkdir()
-    _write_json(
-        task_dir / "brief.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "objective": "Run a small route",
-            "in_scope": ["runtime"],
-            "out_of_scope": [],
-            "constraints": ["local only"],
-            "acceptance_criteria": ["route works"],
-            "risk_level": "low",
-        },
-    )
-    _write_json(
-        task_dir / "run-state.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "current_stage": "clarify",
-            "status": "in_progress",
-            "completed_gates": ["clarification_complete"],
-            "failed_gates": [],
-            "retries": {},
-            "current_task_id": "",
-            "spec_review_approved": False,
-            "quality_review_approved": False,
-        },
-    )
-    return task_dir
-
-
-def test_finalize_blocks_missing_review_flags(tmp_path: Path) -> None:
+def test_finalize_blocks_missing_review_flags(make_task_dir: Callable[[Path], Path], write_json: Callable[[Path, dict], None], tmp_path: Path) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
+    task_dir = make_task_dir(tmp_path)
     run_state = json.loads((task_dir / "run-state.json").read_text(encoding="utf-8"))
     run_state["current_stage"] = "quality-review"
-    _write_json(task_dir / "run-state.json", run_state)
-    _write_json(
+    write_json(task_dir / "run-state.json", run_state)
+    write_json(
         task_dir / "review-report.json",
         {
             "schema_version": "0.1",
@@ -70,10 +33,10 @@ def test_finalize_blocks_missing_review_flags(tmp_path: Path) -> None:
         advance_to_next_stage(task_dir=task_dir, policy=policy, route_name="small", current_stage="quality-review")
 
 
-def test_run_route_rejects_non_approved_quality_review(tmp_path: Path) -> None:
+def test_run_route_rejects_non_approved_quality_review(make_task_dir: Callable[[Path], Path], write_json: Callable[[Path, dict], None], tmp_path: Path) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_json(
+    task_dir = make_task_dir(tmp_path)
+    write_json(
         task_dir / "review-report.json",
         {
             "schema_version": "0.1",
@@ -89,10 +52,10 @@ def test_run_route_rejects_non_approved_quality_review(tmp_path: Path) -> None:
         run_route(task_dir=task_dir, policy=policy, route_name="small")
 
 
-def test_run_route_rejects_approved_review_with_open_blockers(tmp_path: Path) -> None:
+def test_run_route_rejects_approved_review_with_open_blockers(make_task_dir: Callable[[Path], Path], write_json: Callable[[Path, dict], None], tmp_path: Path) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_json(
+    task_dir = make_task_dir(tmp_path)
+    write_json(
         task_dir / "review-report.json",
         {
             "schema_version": "0.1",
@@ -110,10 +73,10 @@ def test_run_route_rejects_approved_review_with_open_blockers(tmp_path: Path) ->
         run_route(task_dir=task_dir, policy=policy, route_name="small")
 
 
-def test_run_route_rejects_approved_quality_review_marked_unsafe(tmp_path: Path) -> None:
+def test_run_route_rejects_approved_quality_review_marked_unsafe(make_task_dir: Callable[[Path], Path], write_json: Callable[[Path, dict], None], tmp_path: Path) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_json(
+    task_dir = make_task_dir(tmp_path)
+    write_json(
         task_dir / "review-report.json",
         {
             "schema_version": "0.1",
@@ -131,10 +94,10 @@ def test_run_route_rejects_approved_quality_review_marked_unsafe(tmp_path: Path)
         run_route(task_dir=task_dir, policy=policy, route_name="small")
 
 
-def test_run_route_rejects_approved_spec_review_marked_unsafe(tmp_path: Path) -> None:
+def test_run_route_rejects_approved_spec_review_marked_unsafe(make_task_dir: Callable[[Path], Path], write_json: Callable[[Path, dict], None], tmp_path: Path) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_json(
+    task_dir = make_task_dir(tmp_path)
+    write_json(
         task_dir / "review-report.json",
         {
             "schema_version": "0.1",

--- a/tests/runtime/test_rewind.py
+++ b/tests/runtime/test_rewind.py
@@ -1,7 +1,6 @@
 import json
+from collections.abc import Callable
 from pathlib import Path
-
-from jsonschema import Draft202012Validator
 
 from forgeflow_runtime.orchestrator import load_runtime_policy, run_route, step_back
 
@@ -9,117 +8,34 @@ from forgeflow_runtime.orchestrator import load_runtime_policy, run_route, step_
 ROOT = Path(__file__).resolve().parents[2]
 
 
-def _write_json(path: Path, payload: dict) -> None:
-    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-
-
-def _load_schema(name: str) -> dict:
-    return json.loads((ROOT / "schemas" / f"{name}.schema.json").read_text(encoding="utf-8"))
-
-
-def _assert_schema_valid(name: str, payload: dict) -> None:
-    errors = sorted(Draft202012Validator(_load_schema(name)).iter_errors(payload), key=lambda err: list(err.path))
-    assert not errors, [f"{list(err.path)}: {err.message}" for err in errors]
-
-
-def _make_task_dir(tmp_path: Path) -> Path:
-    task_dir = tmp_path / "task"
-    task_dir.mkdir()
-    _write_json(
-        task_dir / "brief.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "objective": "Run a small route",
-            "in_scope": ["runtime"],
-            "out_of_scope": [],
-            "constraints": ["local only"],
-            "acceptance_criteria": ["route works"],
-            "risk_level": "low",
-        },
-    )
-    _write_json(
-        task_dir / "run-state.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "current_stage": "clarify",
-            "status": "in_progress",
-            "completed_gates": ["clarification_complete"],
-            "failed_gates": [],
-            "retries": {},
-            "current_task_id": "",
-            "spec_review_approved": False,
-            "quality_review_approved": False,
-        },
-    )
-    return task_dir
-
-
-def _write_medium_plan_artifacts(task_dir: Path, *, route_name: str = "medium") -> None:
-    _write_json(
-        task_dir / "plan.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "steps": [
-                {
-                    "id": "step-1",
-                    "objective": "update workflow docs",
-                    "dependencies": [],
-                    "expected_output": "workflow docs reflect medium route behavior",
-                    "verification": "pytest tests/runtime/test_rewind.py -q",
-                    "rollback_note": "remove incomplete workflow edits if validation fails",
-                }
-            ],
-        },
-    )
-    _write_json(
-        task_dir / "plan-ledger.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "route": route_name,
-            "completed_stages": [],
-            "completed_gates": [],
-            "retries": {},
-            "current_task_id": "task-1",
-            "tasks": [
-                {
-                    "id": "task-1",
-                    "title": "update workflow docs",
-                    "depends_on": [],
-                    "files": ["docs/workflow.md"],
-                    "parallel_safe": False,
-                    "status": "in_progress",
-                    "required_gates": ["machine", "validator"],
-                    "evidence_refs": [],
-                    "attempt_count": 0,
-                }
-            ],
-        },
-    )
-
-
-def test_step_back_rewinds_to_previous_stage(tmp_path: Path) -> None:
+def test_step_back_rewinds_to_previous_stage(
+    tmp_path: Path,
+    make_task_dir: Callable[[Path], Path],
+    assert_schema_valid: Callable[[str, dict], None],
+) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
+    task_dir = make_task_dir(tmp_path)
     state = step_back(task_dir=task_dir, policy=policy, route_name="small", current_stage="quality-review")
 
     assert state["current_stage"] == "execute"
     assert state["status"] == "in_progress"
     checkpoint = json.loads((task_dir / "checkpoint.json").read_text(encoding="utf-8"))
-    _assert_schema_valid("checkpoint", checkpoint)
+    assert_schema_valid("checkpoint", checkpoint)
     assert checkpoint["route"] == "small"
     assert checkpoint["current_stage"] == "execute"
     assert checkpoint["next_action"] == "Resume at quality-review after reloading canonical artifacts."
 
 
-def test_step_back_rewinds_plan_ledger_progress_for_medium_route(tmp_path: Path) -> None:
+def test_step_back_rewinds_plan_ledger_progress_for_medium_route(
+    tmp_path: Path,
+    make_task_dir: Callable[[Path], Path],
+    medium_plan_artifacts: Callable[..., None],
+    write_json: Callable[[Path, dict], None],
+) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_medium_plan_artifacts(task_dir)
-    _write_json(
+    task_dir = make_task_dir(tmp_path)
+    medium_plan_artifacts(task_dir)
+    write_json(
         task_dir / "run-state.json",
         {
             "schema_version": "0.1",
@@ -134,7 +50,7 @@ def test_step_back_rewinds_plan_ledger_progress_for_medium_route(tmp_path: Path)
             "quality_review_approved": False,
         },
     )
-    _write_json(
+    write_json(
         task_dir / "plan-ledger.json",
         {
             "schema_version": "0.1",
@@ -162,7 +78,7 @@ def test_step_back_rewinds_plan_ledger_progress_for_medium_route(tmp_path: Path)
             ],
         },
     )
-    _write_json(
+    write_json(
         task_dir / "checkpoint.json",
         {
             "schema_version": "0.1",
@@ -179,7 +95,7 @@ def test_step_back_rewinds_plan_ledger_progress_for_medium_route(tmp_path: Path)
             "updated_at": "2026-04-22T00:00:00Z",
         },
     )
-    _write_json(
+    write_json(
         task_dir / "session-state.json",
         {
             "schema_version": "0.1",
@@ -196,7 +112,7 @@ def test_step_back_rewinds_plan_ledger_progress_for_medium_route(tmp_path: Path)
             "updated_at": "2026-04-22T00:00:00Z",
         },
     )
-    _write_json(
+    write_json(
         task_dir / "review-report.json",
         {
             "schema_version": "0.1",
@@ -231,11 +147,16 @@ def test_step_back_rewinds_plan_ledger_progress_for_medium_route(tmp_path: Path)
     ]
 
 
-def test_step_back_large_route_preserves_spec_evidence_and_clears_quality_flag(tmp_path: Path) -> None:
+def test_step_back_large_route_preserves_spec_evidence_and_clears_quality_flag(
+    tmp_path: Path,
+    make_task_dir: Callable[[Path], Path],
+    medium_plan_artifacts: Callable[..., None],
+    write_json: Callable[[Path, dict], None],
+) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_medium_plan_artifacts(task_dir, route_name="large_high_risk")
-    _write_json(
+    task_dir = make_task_dir(tmp_path)
+    medium_plan_artifacts(task_dir, route_name="large_high_risk")
+    write_json(
         task_dir / "run-state.json",
         {
             "schema_version": "0.1",
@@ -250,7 +171,7 @@ def test_step_back_large_route_preserves_spec_evidence_and_clears_quality_flag(t
             "quality_review_approved": True,
         },
     )
-    _write_json(
+    write_json(
         task_dir / "plan-ledger.json",
         {
             "schema_version": "0.1",

--- a/tests/runtime/test_route_execution.py
+++ b/tests/runtime/test_route_execution.py
@@ -1,11 +1,11 @@
 import json
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
-from jsonschema import Draft202012Validator
 
 from forgeflow_runtime.orchestrator import RuntimeViolation, load_runtime_policy, run_route
-from forgeflow_runtime.route_execution import route_entry_decision, route_iteration_stages, stage_completion_status
+from forgeflow_runtime.route_execution import route_entry_decision, route_iteration_stages
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -49,36 +49,15 @@ def test_route_entry_decision_marks_complete_route() -> None:
     assert decision.already_complete is True
 
 
-def test_stage_completion_status_marks_finalize_success() -> None:
-    assert stage_completion_status("finalize", existing_final_status=None) == ("completed", "success")
-
-
-def test_stage_completion_status_preserves_long_run_final_status() -> None:
-    assert stage_completion_status("long-run", existing_final_status="partial") == ("completed", "partial")
-
-
-def test_stage_completion_status_leaves_intermediate_stage_in_progress() -> None:
-    assert stage_completion_status("quality-review", existing_final_status=None) == ("in_progress", None)
-
-
-def _write_json(path: Path, payload: dict) -> None:
-    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-
-
-def _load_schema(name: str) -> dict:
-    return json.loads((ROOT / "schemas" / f"{name}.schema.json").read_text(encoding="utf-8"))
-
-
-def _assert_schema_valid(name: str, payload: dict) -> None:
-    errors = sorted(Draft202012Validator(_load_schema(name)).iter_errors(payload), key=lambda err: list(err.path))
-    assert not errors, [f"{list(err.path)}: {err.message}" for err in errors]
-
-
-def test_small_route_runs_end_to_end_and_updates_state(tmp_path: Path) -> None:
+def test_small_route_runs_end_to_end_and_updates_state(
+    tmp_path: Path,
+    write_json: Callable[[Path, dict], None],
+    assert_schema_valid: Callable[[str, dict], None],
+) -> None:
     policy = load_runtime_policy(ROOT)
     task_dir = tmp_path / "task"
     task_dir.mkdir()
-    _write_json(
+    write_json(
         task_dir / "brief.json",
         {
             "schema_version": "0.1",
@@ -91,7 +70,7 @@ def test_small_route_runs_end_to_end_and_updates_state(tmp_path: Path) -> None:
             "risk_level": "low",
         },
     )
-    _write_json(
+    write_json(
         task_dir / "review-report.json",
         {
             "schema_version": "0.1",
@@ -115,10 +94,10 @@ def test_small_route_runs_end_to_end_and_updates_state(tmp_path: Path) -> None:
         "quality_review_passed",
         "ready_to_finalize",
     ]
-    _assert_schema_valid("run-state", result)
+    assert_schema_valid("run-state", result)
 
     decision_log = json.loads((task_dir / "decision-log.json").read_text(encoding="utf-8"))
-    _assert_schema_valid("decision-log", decision_log)
+    assert_schema_valid("decision-log", decision_log)
     decisions = [entry["decision"] for entry in decision_log["entries"]]
     assert decisions == [
         "route selected: small",
@@ -129,11 +108,14 @@ def test_small_route_runs_end_to_end_and_updates_state(tmp_path: Path) -> None:
     ]
 
 
-def test_large_route_runs_end_to_end_and_collects_both_review_flags(tmp_path: Path) -> None:
+def test_large_route_runs_end_to_end_and_collects_both_review_flags(
+    tmp_path: Path,
+    write_json: Callable[[Path, dict], None],
+) -> None:
     policy = load_runtime_policy(ROOT)
     task_dir = tmp_path / "large-task"
     task_dir.mkdir()
-    _write_json(
+    write_json(
         task_dir / "brief.json",
         {
             "schema_version": "0.1",
@@ -146,7 +128,7 @@ def test_large_route_runs_end_to_end_and_collects_both_review_flags(tmp_path: Pa
             "risk_level": "high",
         },
     )
-    _write_json(
+    write_json(
         task_dir / "plan.json",
         {
             "schema_version": "0.1",
@@ -161,7 +143,7 @@ def test_large_route_runs_end_to_end_and_collects_both_review_flags(tmp_path: Pa
             ],
         },
     )
-    _write_json(
+    write_json(
         task_dir / "plan-ledger.json",
         {
             "schema_version": "0.1",
@@ -183,7 +165,7 @@ def test_large_route_runs_end_to_end_and_collects_both_review_flags(tmp_path: Pa
             ]
         },
     )
-    _write_json(
+    write_json(
         task_dir / "review-report-spec.json",
         {
             "schema_version": "0.1",
@@ -195,7 +177,7 @@ def test_large_route_runs_end_to_end_and_collects_both_review_flags(tmp_path: Pa
             "next_action": "quality-review로 진행",
         },
     )
-    _write_json(
+    write_json(
         task_dir / "review-report-quality.json",
         {
             "schema_version": "0.1",
@@ -207,7 +189,7 @@ def test_large_route_runs_end_to_end_and_collects_both_review_flags(tmp_path: Pa
             "next_action": "finalize 가능",
         },
     )
-    _write_json(
+    write_json(
         task_dir / "eval-record.json",
         {
             "schema_version": "0.1",
@@ -236,11 +218,14 @@ def test_large_route_runs_end_to_end_and_collects_both_review_flags(tmp_path: Pa
     ]
 
 
-def test_large_route_rejects_missing_eval_record_before_long_run(tmp_path: Path) -> None:
+def test_large_route_rejects_missing_eval_record_before_long_run(
+    tmp_path: Path,
+    write_json: Callable[[Path, dict], None],
+) -> None:
     policy = load_runtime_policy(ROOT)
     task_dir = tmp_path / "large-task-missing-eval"
     task_dir.mkdir()
-    _write_json(
+    write_json(
         task_dir / "brief.json",
         {
             "schema_version": "0.1",
@@ -253,7 +238,7 @@ def test_large_route_rejects_missing_eval_record_before_long_run(tmp_path: Path)
             "risk_level": "high",
         },
     )
-    _write_json(
+    write_json(
         task_dir / "plan.json",
         {
             "schema_version": "0.1",
@@ -268,7 +253,7 @@ def test_large_route_rejects_missing_eval_record_before_long_run(tmp_path: Path)
             ],
         },
     )
-    _write_json(
+    write_json(
         task_dir / "plan-ledger.json",
         {
             "schema_version": "0.1",
@@ -290,7 +275,7 @@ def test_large_route_rejects_missing_eval_record_before_long_run(tmp_path: Path)
             ]
         },
     )
-    _write_json(
+    write_json(
         task_dir / "review-report-spec.json",
         {
             "schema_version": "0.1",
@@ -302,7 +287,7 @@ def test_large_route_rejects_missing_eval_record_before_long_run(tmp_path: Path)
             "next_action": "quality-review로 진행",
         },
     )
-    _write_json(
+    write_json(
         task_dir / "review-report-quality.json",
         {
             "schema_version": "0.1",

--- a/tests/runtime/test_route_selection.py
+++ b/tests/runtime/test_route_selection.py
@@ -1,70 +1,23 @@
 import json
+from collections.abc import Callable
 from pathlib import Path
-
-from jsonschema import Draft202012Validator
 
 from forgeflow_runtime.orchestrator import escalate_route
 
 
-ROOT = Path(__file__).resolve().parents[2]
-
-
-def _write_json(path: Path, payload: dict) -> None:
-    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-
-
-def _load_schema(name: str) -> dict:
-    return json.loads((ROOT / "schemas" / f"{name}.schema.json").read_text(encoding="utf-8"))
-
-
-def _assert_schema_valid(name: str, payload: dict) -> None:
-    errors = sorted(Draft202012Validator(_load_schema(name)).iter_errors(payload), key=lambda err: list(err.path))
-    assert not errors, [f"{list(err.path)}: {err.message}" for err in errors]
-
-
-def _make_task_dir(tmp_path: Path) -> Path:
-    task_dir = tmp_path / "task"
-    task_dir.mkdir()
-    _write_json(
-        task_dir / "brief.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "objective": "Run a small route",
-            "in_scope": ["runtime"],
-            "out_of_scope": [],
-            "constraints": ["local only"],
-            "acceptance_criteria": ["route works"],
-            "risk_level": "low",
-        },
-    )
-    _write_json(
-        task_dir / "run-state.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "current_stage": "clarify",
-            "status": "in_progress",
-            "completed_gates": ["clarification_complete"],
-            "failed_gates": [],
-            "retries": {},
-            "current_task_id": "",
-            "spec_review_approved": False,
-            "quality_review_approved": False,
-        },
-    )
-    return task_dir
-
-
-def test_escalate_route_switches_to_large_high_risk(tmp_path: Path) -> None:
-    task_dir = _make_task_dir(tmp_path)
+def test_escalate_route_switches_to_large_high_risk(
+    tmp_path: Path,
+    make_task_dir: Callable[[Path], Path],
+    assert_schema_valid: Callable[[str, dict], None],
+) -> None:
+    task_dir = make_task_dir(tmp_path)
 
     state = escalate_route(task_dir=task_dir, from_route="small")
 
     assert state["status"] == "blocked"
     assert state["current_stage"] == "clarify"
     checkpoint = json.loads((task_dir / "checkpoint.json").read_text(encoding="utf-8"))
-    _assert_schema_valid("checkpoint", checkpoint)
+    assert_schema_valid("checkpoint", checkpoint)
     assert checkpoint["route"] == "large_high_risk"
     assert checkpoint["current_stage"] == "clarify"
     assert checkpoint["next_action"] == "Resume at plan after reloading canonical artifacts."

--- a/tests/runtime/test_runtime_fixtures.py
+++ b/tests/runtime/test_runtime_fixtures.py
@@ -1,0 +1,49 @@
+import ast
+from collections.abc import Callable
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_runtime_tests_do_not_define_local_json_writer_helpers() -> None:
+    local_helpers = []
+    for path in (ROOT / "tests" / "runtime").glob("test_*.py"):
+        if path.name == "test_runtime_fixtures.py":
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        local_helpers.extend(
+            f"{path.relative_to(ROOT)}::{node.name}"
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name == "_write_json"
+        )
+
+    assert local_helpers == []
+
+
+def test_runtime_tests_do_not_define_local_medium_plan_ledger_helpers() -> None:
+    local_helpers = []
+    for path in (ROOT / "tests" / "runtime").glob("test_*.py"):
+        if path.name == "test_runtime_fixtures.py":
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        local_helpers.extend(
+            f"{path.relative_to(ROOT)}::{node.name}"
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name == "_write_medium_plan_ledger"
+        )
+
+    assert local_helpers == []
+
+
+def test_medium_plan_artifacts_fixture_writes_plan_and_ledger(
+    make_task_dir: Callable[[Path], Path],
+    medium_plan_artifacts: Callable[..., None],
+    tmp_path: Path,
+) -> None:
+    task_dir = make_task_dir(tmp_path)
+
+    medium_plan_artifacts(task_dir)
+
+    assert (task_dir / "plan.json").exists()
+    assert (task_dir / "plan-ledger.json").exists()

--- a/tests/runtime/test_stage_transitions.py
+++ b/tests/runtime/test_stage_transitions.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -10,106 +11,32 @@ from forgeflow_runtime.orchestrator import RuntimeViolation, advance_to_next_sta
 ROOT = Path(__file__).resolve().parents[2]
 
 
-def _write_json(path: Path, payload: dict) -> None:
-    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-
-
-def _make_task_dir(tmp_path: Path) -> Path:
-    task_dir = tmp_path / "task"
-    task_dir.mkdir()
-    _write_json(
-        task_dir / "brief.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "objective": "Run a small route",
-            "in_scope": ["runtime"],
-            "out_of_scope": [],
-            "constraints": ["local only"],
-            "acceptance_criteria": ["route works"],
-            "risk_level": "low",
-        },
-    )
-    _write_json(
-        task_dir / "run-state.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "current_stage": "clarify",
-            "status": "in_progress",
-            "completed_gates": ["clarification_complete"],
-            "failed_gates": [],
-            "retries": {},
-            "current_task_id": "",
-            "spec_review_approved": False,
-            "quality_review_approved": False,
-        },
-    )
-    return task_dir
-
-
-def _write_medium_plan_artifacts(task_dir: Path, *, route_name: str = "medium") -> None:
-    _write_json(
-        task_dir / "plan.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "steps": [
-                {
-                    "id": "step-1",
-                    "objective": "update workflow docs",
-                    "dependencies": [],
-                    "expected_output": "workflow docs reflect medium route behavior",
-                    "verification": "pytest tests/runtime/test_stage_transitions.py -q",
-                    "rollback_note": "remove incomplete workflow edits if validation fails",
-                }
-            ],
-        },
-    )
-    _write_json(
-        task_dir / "plan-ledger.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "route": route_name,
-            "completed_stages": [],
-            "completed_gates": [],
-            "retries": {},
-            "current_task_id": "task-1",
-            "tasks": [
-                {
-                    "id": "task-1",
-                    "title": "update workflow docs",
-                    "depends_on": [],
-                    "files": ["docs/workflow.md"],
-                    "parallel_safe": False,
-                    "status": "in_progress",
-                    "required_gates": ["machine", "validator"],
-                    "evidence_refs": [],
-                    "attempt_count": 0,
-                }
-            ],
-        },
-    )
-
-
-def test_advance_blocks_missing_entry_artifacts(tmp_path: Path) -> None:
+def test_advance_blocks_missing_entry_artifacts(
+    tmp_path: Path,
+    make_task_dir: Callable[[Path], Path],
+    medium_plan_artifacts: Callable[..., None],
+) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_medium_plan_artifacts(task_dir, route_name="large_high_risk")
+    task_dir = make_task_dir(tmp_path)
+    medium_plan_artifacts(task_dir, route_name="large_high_risk")
     (task_dir / "run-state.json").unlink()
 
     with pytest.raises(RuntimeViolation, match="missing required artifacts for spec-review: run-state"):
         advance_to_next_stage(task_dir=task_dir, policy=policy, route_name="large_high_risk", current_stage="execute")
 
 
-def test_advance_can_execute_next_stage_immediately(tmp_path: Path) -> None:
+def test_advance_can_execute_next_stage_immediately(
+    tmp_path: Path,
+    make_task_dir: Callable[[Path], Path],
+    write_json: Callable[[Path, dict], None],
+    medium_plan_artifacts: Callable[..., None],
+) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_medium_plan_artifacts(task_dir)
+    task_dir = make_task_dir(tmp_path)
+    medium_plan_artifacts(task_dir)
     run_state = json.loads((task_dir / "run-state.json").read_text(encoding="utf-8"))
     run_state["current_stage"] = "plan"
-    _write_json(task_dir / "run-state.json", run_state)
+    write_json(task_dir / "run-state.json", run_state)
 
     result = advance_to_next_stage(
         task_dir=task_dir,
@@ -129,13 +56,18 @@ def test_advance_can_execute_next_stage_immediately(tmp_path: Path) -> None:
     assert "stub-codex-output" in (task_dir / "execute-output.md").read_text(encoding="utf-8")
 
 
-def test_advance_execute_failure_keeps_previous_stage_state(tmp_path: Path) -> None:
+def test_advance_execute_failure_keeps_previous_stage_state(
+    tmp_path: Path,
+    make_task_dir: Callable[[Path], Path],
+    write_json: Callable[[Path, dict], None],
+    medium_plan_artifacts: Callable[..., None],
+) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_medium_plan_artifacts(task_dir)
+    task_dir = make_task_dir(tmp_path)
+    medium_plan_artifacts(task_dir)
     run_state = json.loads((task_dir / "run-state.json").read_text(encoding="utf-8"))
     run_state["current_stage"] = "plan"
-    _write_json(task_dir / "run-state.json", run_state)
+    write_json(task_dir / "run-state.json", run_state)
 
     with pytest.raises(GenerationError, match="unknown role: nonexistent-role"):
         advance_to_next_stage(

--- a/tests/runtime/test_status_resume.py
+++ b/tests/runtime/test_status_resume.py
@@ -1,4 +1,5 @@
 import json
+from typing import Callable
 from pathlib import Path
 
 from forgeflow_runtime.orchestrator import load_runtime_policy, resume_task, status_summary
@@ -7,93 +8,10 @@ from forgeflow_runtime.orchestrator import load_runtime_policy, resume_task, sta
 ROOT = Path(__file__).resolve().parents[2]
 
 
-def _write_json(path: Path, payload: dict) -> None:
-    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-
-
-def _make_task_dir(tmp_path: Path) -> Path:
-    task_dir = tmp_path / "task"
-    task_dir.mkdir()
-    _write_json(
-        task_dir / "brief.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "objective": "Run a small route",
-            "in_scope": ["runtime"],
-            "out_of_scope": [],
-            "constraints": ["local only"],
-            "acceptance_criteria": ["route works"],
-            "risk_level": "low",
-        },
-    )
-    _write_json(
-        task_dir / "run-state.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "current_stage": "clarify",
-            "status": "in_progress",
-            "completed_gates": ["clarification_complete"],
-            "failed_gates": [],
-            "retries": {},
-            "current_task_id": "",
-            "spec_review_approved": False,
-            "quality_review_approved": False,
-        },
-    )
-    return task_dir
-
-
-def _write_medium_plan_artifacts(task_dir: Path, *, route_name: str = "medium") -> None:
-    _write_json(
-        task_dir / "plan.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "steps": [
-                {
-                    "id": "step-1",
-                    "objective": "update workflow docs",
-                    "dependencies": [],
-                    "expected_output": "workflow docs reflect medium route behavior",
-                    "verification": "pytest tests/runtime/test_status_resume.py -q",
-                    "rollback_note": "remove incomplete workflow edits if validation fails",
-                }
-            ],
-        },
-    )
-    _write_json(
-        task_dir / "plan-ledger.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "route": route_name,
-            "completed_stages": [],
-            "completed_gates": [],
-            "retries": {},
-            "current_task_id": "task-1",
-            "tasks": [
-                {
-                    "id": "task-1",
-                    "title": "update workflow docs",
-                    "depends_on": [],
-                    "files": ["docs/workflow.md"],
-                    "parallel_safe": False,
-                    "status": "in_progress",
-                    "required_gates": ["machine", "validator"],
-                    "evidence_refs": [],
-                    "attempt_count": 0,
-                }
-            ],
-        },
-    )
-
-
-def test_resume_task_reloads_session_state_and_returns_current_truth(tmp_path: Path) -> None:
+def test_resume_task_reloads_session_state_and_returns_current_truth(make_task_dir: Callable[[Path], Path], write_json: Callable[[Path, dict], None], tmp_path: Path) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_json(
+    task_dir = make_task_dir(tmp_path)
+    write_json(
         task_dir / "run-state.json",
         {
             "schema_version": "0.1",
@@ -108,7 +26,7 @@ def test_resume_task_reloads_session_state_and_returns_current_truth(tmp_path: P
             "quality_review_approved": False,
         },
     )
-    _write_json(
+    write_json(
         task_dir / "checkpoint.json",
         {
             "schema_version": "0.1",
@@ -124,7 +42,7 @@ def test_resume_task_reloads_session_state_and_returns_current_truth(tmp_path: P
             "updated_at": "2026-04-22T00:05:00Z"
         },
     )
-    _write_json(
+    write_json(
         task_dir / "review-report.json",
         {
             "schema_version": "0.1",
@@ -136,7 +54,7 @@ def test_resume_task_reloads_session_state_and_returns_current_truth(tmp_path: P
             "next_action": "finalize 가능",
         },
     )
-    _write_json(
+    write_json(
         task_dir / "session-state.json",
         {
             "schema_version": "0.1",
@@ -162,10 +80,10 @@ def test_resume_task_reloads_session_state_and_returns_current_truth(tmp_path: P
     assert result["next_action"] == "checkpoint truth"
 
 
-def test_status_summary_reports_current_truth(tmp_path: Path) -> None:
+def test_status_summary_reports_current_truth(make_task_dir: Callable[[Path], Path], write_json: Callable[[Path, dict], None], tmp_path: Path) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_json(
+    task_dir = make_task_dir(tmp_path)
+    write_json(
         task_dir / "checkpoint.json",
         {
             "schema_version": "0.1",
@@ -180,7 +98,7 @@ def test_status_summary_reports_current_truth(tmp_path: Path) -> None:
             "updated_at": "2026-04-22T00:05:00Z"
         },
     )
-    _write_json(
+    write_json(
         task_dir / "session-state.json",
         {
             "schema_version": "0.1",
@@ -208,11 +126,16 @@ def test_status_summary_reports_current_truth(tmp_path: Path) -> None:
     assert result["next_action"] == "execute로 진행"
 
 
-def test_resume_task_prefers_plan_ledger_current_task_for_medium_route(tmp_path: Path) -> None:
+def test_resume_task_prefers_plan_ledger_current_task_for_medium_route(
+    make_task_dir: Callable[[Path], Path],
+    medium_plan_artifacts: Callable[..., None],
+    write_json: Callable[[Path, dict], None],
+    tmp_path: Path,
+) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_medium_plan_artifacts(task_dir)
-    _write_json(
+    task_dir = make_task_dir(tmp_path)
+    medium_plan_artifacts(task_dir)
+    write_json(
         task_dir / "run-state.json",
         {
             "schema_version": "0.1",
@@ -227,7 +150,7 @@ def test_resume_task_prefers_plan_ledger_current_task_for_medium_route(tmp_path:
             "quality_review_approved": False,
         },
     )
-    _write_json(
+    write_json(
         task_dir / "checkpoint.json",
         {
             "schema_version": "0.1",
@@ -243,7 +166,7 @@ def test_resume_task_prefers_plan_ledger_current_task_for_medium_route(tmp_path:
             "updated_at": "2026-04-22T00:05:00Z"
         },
     )
-    _write_json(
+    write_json(
         task_dir / "session-state.json",
         {
             "schema_version": "0.1",
@@ -265,11 +188,16 @@ def test_resume_task_prefers_plan_ledger_current_task_for_medium_route(tmp_path:
     assert result["current_task_id"] == "task-1"
 
 
-def test_status_summary_prefers_plan_ledger_current_task_for_medium_route(tmp_path: Path) -> None:
+def test_status_summary_prefers_plan_ledger_current_task_for_medium_route(
+    make_task_dir: Callable[[Path], Path],
+    medium_plan_artifacts: Callable[..., None],
+    write_json: Callable[[Path, dict], None],
+    tmp_path: Path,
+) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_medium_plan_artifacts(task_dir)
-    _write_json(
+    task_dir = make_task_dir(tmp_path)
+    medium_plan_artifacts(task_dir)
+    write_json(
         task_dir / "run-state.json",
         {
             "schema_version": "0.1",
@@ -284,7 +212,7 @@ def test_status_summary_prefers_plan_ledger_current_task_for_medium_route(tmp_pa
             "quality_review_approved": False,
         },
     )
-    _write_json(
+    write_json(
         task_dir / "plan-ledger.json",
         {
             "schema_version": "0.1",
@@ -309,7 +237,7 @@ def test_status_summary_prefers_plan_ledger_current_task_for_medium_route(tmp_pa
             ],
         },
     )
-    _write_json(
+    write_json(
         task_dir / "checkpoint.json",
         {
             "schema_version": "0.1",
@@ -325,7 +253,7 @@ def test_status_summary_prefers_plan_ledger_current_task_for_medium_route(tmp_pa
             "updated_at": "2026-04-22T00:05:00Z"
         },
     )
-    _write_json(
+    write_json(
         task_dir / "session-state.json",
         {
             "schema_version": "0.1",

--- a/tests/runtime/test_task_management.py
+++ b/tests/runtime/test_task_management.py
@@ -1,61 +1,14 @@
 import json
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
-from jsonschema import Draft202012Validator
 
 from forgeflow_runtime.orchestrator import RuntimeViolation, _canonical_task_id, load_runtime_policy, start_task
 from forgeflow_runtime.task_identity import canonical_task_id
 
 
 ROOT = Path(__file__).resolve().parents[2]
-
-
-def _write_json(path: Path, payload: dict) -> None:
-    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-
-
-def _load_schema(name: str) -> dict:
-    return json.loads((ROOT / "schemas" / f"{name}.schema.json").read_text(encoding="utf-8"))
-
-
-def _assert_schema_valid(name: str, payload: dict) -> None:
-    errors = sorted(Draft202012Validator(_load_schema(name)).iter_errors(payload), key=lambda err: list(err.path))
-    assert not errors, [f"{list(err.path)}: {err.message}" for err in errors]
-
-
-def _make_task_dir(tmp_path: Path) -> Path:
-    task_dir = tmp_path / "task"
-    task_dir.mkdir()
-    _write_json(
-        task_dir / "brief.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "objective": "Run a small route",
-            "in_scope": ["runtime"],
-            "out_of_scope": [],
-            "constraints": ["local only"],
-            "acceptance_criteria": ["route works"],
-            "risk_level": "low",
-        },
-    )
-    _write_json(
-        task_dir / "run-state.json",
-        {
-            "schema_version": "0.1",
-            "task_id": "task-001",
-            "current_stage": "clarify",
-            "status": "in_progress",
-            "completed_gates": ["clarification_complete"],
-            "failed_gates": [],
-            "retries": {},
-            "current_task_id": "",
-            "spec_review_approved": False,
-            "quality_review_approved": False,
-        },
-    )
-    return task_dir
 
 
 def _brief(task_id: str) -> dict:
@@ -86,32 +39,45 @@ def _run_state(task_id: str) -> dict:
     }
 
 
-def test_canonical_task_id_prefers_matching_brief_and_keeps_orchestrator_alias(tmp_path: Path) -> None:
-    _write_json(tmp_path / "brief.json", _brief("task-001"))
-    _write_json(tmp_path / "run-state.json", _run_state("task-001"))
+def test_canonical_task_id_prefers_matching_brief_and_keeps_orchestrator_alias(
+    tmp_path: Path,
+    write_json: Callable[[Path, dict], None],
+) -> None:
+    write_json(tmp_path / "brief.json", _brief("task-001"))
+    write_json(tmp_path / "run-state.json", _run_state("task-001"))
 
     assert canonical_task_id(tmp_path) == "task-001"
     assert _canonical_task_id(tmp_path) == "task-001"
 
 
-def test_canonical_task_id_rejects_brief_run_state_mismatch(tmp_path: Path) -> None:
-    _write_json(tmp_path / "brief.json", _brief("task-001"))
-    _write_json(tmp_path / "run-state.json", _run_state("other-task"))
+def test_canonical_task_id_rejects_brief_run_state_mismatch(
+    tmp_path: Path,
+    write_json: Callable[[Path, dict], None],
+) -> None:
+    write_json(tmp_path / "brief.json", _brief("task-001"))
+    write_json(tmp_path / "run-state.json", _run_state("other-task"))
 
     with pytest.raises(RuntimeViolation, match="run-state.json task_id other-task does not match canonical task_id task-001"):
         canonical_task_id(tmp_path)
 
 
-def test_start_task_rejects_existing_artifacts(tmp_path: Path) -> None:
+def test_start_task_rejects_existing_artifacts(
+    tmp_path: Path,
+    make_task_dir: Callable[[Path], Path],
+    write_json: Callable[[Path, dict], None],
+) -> None:
     policy = load_runtime_policy(ROOT)
-    task_dir = _make_task_dir(tmp_path)
-    _write_json(task_dir / "brief.json", {"schema_version": "0.1", "task_id": "task-001"})
+    task_dir = make_task_dir(tmp_path)
+    write_json(task_dir / "brief.json", {"schema_version": "0.1", "task_id": "task-001"})
 
     with pytest.raises(RuntimeViolation, match="start requires an empty task directory"):
         start_task(task_dir=task_dir, policy=policy, route_name="small")
 
 
-def test_start_task_bootstraps_medium_route_and_session_state(tmp_path: Path) -> None:
+def test_start_task_bootstraps_medium_route_and_session_state(
+    tmp_path: Path,
+    assert_schema_valid: Callable[[str, dict], None],
+) -> None:
     policy = load_runtime_policy(ROOT)
     task_dir = tmp_path / "bootstrapped-medium"
 
@@ -123,7 +89,7 @@ def test_start_task_bootstraps_medium_route_and_session_state(tmp_path: Path) ->
     assert "plan-ledger.json" in result["created_artifacts"]
 
     session_state = json.loads((task_dir / "session-state.json").read_text(encoding="utf-8"))
-    _assert_schema_valid("session-state", session_state)
+    assert_schema_valid("session-state", session_state)
     assert session_state["route"] == "medium"
     assert session_state["run_state_ref"] == "run-state.json"
     assert session_state["plan_ref"] == "plan.json"


### PR DESCRIPTION
## Summary
- Rebuilds the runtime fixture consolidation slice on top of the already-merged runtime seams PR.
- Adds shared runtime fixtures and fixture contract coverage.
- Reduces repeated runtime test setup without changing runtime behavior.

## Validation
- `python -m pytest tests/runtime -q`
- `make validate`
- `python -m pytest -q`
- `git diff --check`
