### PR TITLE
FF-MAINT-006: Extract evolution doctor health-check seams

### DIFF
--- a/forgeflow_runtime/evolution_doctor.py
+++ b/forgeflow_runtime/evolution_doctor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
 
@@ -8,6 +9,20 @@ from forgeflow_runtime.evolution_audit import AUDIT_LOG_PATH
 from forgeflow_runtime.evolution_rules import failed_safety_checks, safety_checks
 
 RuleLoader = Callable[[Path], list[tuple[dict[str, Any], Path]]]
+
+
+@dataclass(frozen=True)
+class RuleHealth:
+    rules: list[dict[str, Any]]
+    rule_ids: set[str]
+    issues: list[dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class AuditLogHealth:
+    events_count: int
+    last_event: dict[str, Any] | None
+    issues: list[dict[str, Any]]
 
 
 def audit_required_field_issues(event: dict[str, Any], *, line_number: int) -> list[dict[str, Any]]:
@@ -25,74 +40,59 @@ def audit_required_field_issues(event: dict[str, Any], *, line_number: int) -> l
     ]
 
 
-def doctor_evolution_state(
-    root: Path,
-    *,
-    project_rule_loader: RuleLoader,
-    retired_rule_loader: RuleLoader,
-) -> dict[str, Any]:
-    """Read-only health check for the project-local evolution lifecycle."""
-
-    root = root.resolve()
+def _collect_rule_health(root: Path, *, loader: RuleLoader, source: str, issue_code: str) -> RuleHealth:
+    rules: list[dict[str, Any]] = []
+    rule_ids: set[str] = set()
     issues: list[dict[str, Any]] = []
-    active_rules: list[dict[str, Any]] = []
-    retired_rules: list[dict[str, Any]] = []
 
-    active_ids: set[str] = set()
-    retired_ids: set[str] = set()
-
-    for loader, bucket, ids, source, issue_code in [
-        (project_rule_loader, active_rules, active_ids, "active", "unsafe_active_rule"),
-        (retired_rule_loader, retired_rules, retired_ids, "retired", "unsafe_retired_rule"),
-    ]:
-        try:
-            loaded = loader(root)
-        except json.JSONDecodeError as exc:
-            issues.append(
+    try:
+        loaded = loader(root)
+    except json.JSONDecodeError as exc:
+        return RuleHealth(
+            rules=[],
+            rule_ids=set(),
+            issues=[
                 {
                     "severity": "error",
                     "code": f"invalid_{source}_rule_json",
                     "message": str(exc),
                 }
-            )
-            loaded = []
-        for rule, path in loaded:
-            rule_id = rule.get("id") or path.stem
-            rule_safety_checks = safety_checks(rule)
-            failed = failed_safety_checks(rule_safety_checks)
-            ids.add(str(rule_id))
-            bucket.append(
+            ],
+        )
+
+    for rule, path in loaded:
+        rule_id = rule.get("id") or path.stem
+        rule_safety_checks = safety_checks(rule)
+        failed = failed_safety_checks(rule_safety_checks)
+        rule_ids.add(str(rule_id))
+        rules.append(
+            {
+                "id": rule_id,
+                "path": str(path),
+                "safe_to_execute": not failed,
+                "safety_checks": rule_safety_checks,
+                "failed_safety_checks": failed,
+            }
+        )
+        if failed:
+            issues.append(
                 {
-                    "id": rule_id,
+                    "severity": "error" if source == "active" else "warning",
+                    "code": issue_code,
+                    "rule_id": rule_id,
                     "path": str(path),
-                    "safe_to_execute": not failed,
-                    "safety_checks": rule_safety_checks,
                     "failed_safety_checks": failed,
                 }
             )
-            if failed:
-                issues.append(
-                    {
-                        "severity": "error" if source == "active" else "warning",
-                        "code": issue_code,
-                        "rule_id": rule_id,
-                        "path": str(path),
-                        "failed_safety_checks": failed,
-                    }
-                )
 
-    for duplicate in sorted(active_ids & retired_ids):
-        issues.append(
-            {
-                "severity": "error",
-                "code": "duplicate_active_retired_rule",
-                "rule_id": duplicate,
-            }
-        )
+    return RuleHealth(rules=rules, rule_ids=rule_ids, issues=issues)
 
-    audit_path = root / AUDIT_LOG_PATH
-    audit_events_count = 0
+
+def _audit_log_health(audit_path: Path) -> AuditLogHealth:
+    issues: list[dict[str, Any]] = []
+    events_count = 0
     last_event: dict[str, Any] | None = None
+
     if audit_path.is_file():
         for line_number, line in enumerate(audit_path.read_text(encoding="utf-8").splitlines(), start=1):
             if not line.strip():
@@ -109,9 +109,50 @@ def doctor_evolution_state(
                     }
                 )
                 continue
-            audit_events_count += 1
+            events_count += 1
             last_event = event
             issues.extend(audit_required_field_issues(event, line_number=line_number))
+
+    return AuditLogHealth(events_count=events_count, last_event=last_event, issues=issues)
+
+
+def doctor_evolution_state(
+    root: Path,
+    *,
+    project_rule_loader: RuleLoader,
+    retired_rule_loader: RuleLoader,
+) -> dict[str, Any]:
+    """Read-only health check for the project-local evolution lifecycle."""
+
+    root = root.resolve()
+    active_health = _collect_rule_health(
+        root,
+        loader=project_rule_loader,
+        source="active",
+        issue_code="unsafe_active_rule",
+    )
+    retired_health = _collect_rule_health(
+        root,
+        loader=retired_rule_loader,
+        source="retired",
+        issue_code="unsafe_retired_rule",
+    )
+    issues = [*active_health.issues, *retired_health.issues]
+    active_rules = active_health.rules
+    retired_rules = retired_health.rules
+
+    for duplicate in sorted(active_health.rule_ids & retired_health.rule_ids):
+        issues.append(
+            {
+                "severity": "error",
+                "code": "duplicate_active_retired_rule",
+                "rule_id": duplicate,
+            }
+        )
+
+    audit_path = root / AUDIT_LOG_PATH
+    audit_health = _audit_log_health(audit_path)
+    issues.extend(audit_health.issues)
 
     return {
         "ok": not any(issue.get("severity") == "error" for issue in issues),
@@ -119,8 +160,8 @@ def doctor_evolution_state(
         "summary": {
             "active_rules": len(active_rules),
             "retired_rules": len(retired_rules),
-            "audit_events": audit_events_count,
-            "last_event": last_event,
+            "audit_events": audit_health.events_count,
+            "last_event": audit_health.last_event,
             "unsafe_active_rules": sum(1 for rule in active_rules if not rule["safe_to_execute"]),
             "unsafe_retired_rules": sum(1 for rule in retired_rules if not rule["safe_to_execute"]),
             "restore_candidates": len(retired_rules),

--- a/tests/evolution/test_doctor.py
+++ b/tests/evolution/test_doctor.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 
 from forgeflow_runtime.evolution import adopt_example_rule, doctor_evolution_state
+from forgeflow_runtime.evolution_doctor import _audit_log_health, _collect_rule_health
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -20,6 +21,59 @@ def _write_project_rule(tmp_path: Path, rule: dict) -> None:
 
 def _valid_rule() -> dict:
     return json.loads((ROOT / "examples" / "evolution" / "no-env-commit-rule.json").read_text(encoding="utf-8"))
+
+
+def test_rule_health_seam_reports_rule_safety_and_issues(tmp_path: Path) -> None:
+    rule = _valid_rule()
+    rule["check"]["command_id"] = "evil-command"
+    _write_project_rule(tmp_path, rule)
+
+    health = _collect_rule_health(
+        tmp_path,
+        loader=lambda root: [(rule, root / ".forgeflow" / "evolution" / "rules" / "no-env-commit-rule.json")],
+        source="active",
+        issue_code="unsafe_active_rule",
+    )
+
+    assert health.rule_ids == {"no-env-commit"}
+    assert health.rules[0]["safe_to_execute"] is False
+    assert health.issues == [
+        {
+            "severity": "error",
+            "code": "unsafe_active_rule",
+            "rule_id": "no-env-commit",
+            "path": str(tmp_path / ".forgeflow" / "evolution" / "rules" / "no-env-commit-rule.json"),
+            "failed_safety_checks": ["approved_command", "approved_command_contract"],
+        }
+    ]
+
+
+def test_audit_log_health_seam_reports_counts_last_event_and_issues(tmp_path: Path) -> None:
+    audit_path = tmp_path / ".forgeflow" / "evolution" / "audit-log.jsonl"
+    audit_path.parent.mkdir(parents=True)
+    audit_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "timestamp": "2026-04-27T00:00:00Z",
+                "event": "adopt",
+                "rule_id": "x",
+                "passed": True,
+            }
+        )
+        + "\n"
+        + '{"event":"missing-fields","rule_id":"x"}\n'
+        + "not-json\n",
+        encoding="utf-8",
+    )
+
+    health = _audit_log_health(audit_path)
+
+    assert health.events_count == 2
+    assert health.last_event == {"event": "missing-fields", "rule_id": "x"}
+    assert [issue["code"] for issue in health.issues] == ["audit_event_missing_fields", "invalid_audit_json"]
+    assert health.issues[0]["line"] == 2
+    assert health.issues[1]["line"] == 3
 
 
 def test_doctor_reports_clean_lifecycle_state(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Extract active/retired rule health checks into _collect_rule_health
- Extract audit log parsing/counting checks into _audit_log_health
- Add seam-level regression tests while preserving doctor output contract

## Verification
- .venv/bin/python -m pytest tests/evolution/test_doctor.py -q
- git diff --check && make validate && .venv/bin/python -m pytest -q

Closes #51