### PR TITLE
refactor: extract route result seam

### DIFF
--- a/forgeflow_runtime/orchestrator.py
+++ b/forgeflow_runtime/orchestrator.py
@@ -38,7 +38,7 @@ from forgeflow_runtime.plan_ledger import (
 from forgeflow_runtime.operator_routing import role_for_stage
 from forgeflow_runtime.policy_loader import RuntimePolicy, load_runtime_policy
 from forgeflow_runtime.resume_validation import resume_start_index
-from forgeflow_runtime.route_execution import route_entry_decision, route_iteration_stages, stage_completion_status
+from forgeflow_runtime.route_execution import build_route_result, route_entry_decision, route_iteration_stages, stage_completion_status
 from forgeflow_runtime.stage_transition import next_stage_for_transition
 from forgeflow_runtime.task_identity import canonical_task_id as _canonical_task_id
 from forgeflow_runtime.task_identity import task_id as _task_id
@@ -1073,11 +1073,7 @@ def run_route(task_dir: Path, policy: RuntimePolicy, route_name: str) -> dict[st
             session_state=session_state,
         )
 
-    result = dict(run_state)
-    progress = _plan_ledger_progress(plan_ledger) or run_state
-    result["completed_gates"] = list(progress.get("completed_gates", []))
-    result["retries"] = dict(progress.get("retries", result.get("retries", {})))
-    return result
+    return build_route_result(run_state, _plan_ledger_progress(plan_ledger))
 
 
 def retry_stage(task_dir: Path, stage_name: str, max_retries: int = 2) -> dict[str, Any]:

--- a/forgeflow_runtime/route_execution.py
+++ b/forgeflow_runtime/route_execution.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass(frozen=True)
@@ -36,6 +37,14 @@ def route_entry_decision(
 
 def route_iteration_stages(route: list[str], start_index: int) -> list[str]:
     return list(route[start_index:])
+
+
+def build_route_result(run_state: dict[str, Any], plan_ledger: dict[str, Any] | None) -> dict[str, Any]:
+    result = dict(run_state)
+    progress = plan_ledger if plan_ledger is not None else run_state
+    result["completed_gates"] = list(progress.get("completed_gates", []))
+    result["retries"] = dict(progress.get("retries", result.get("retries", {})))
+    return result
 
 
 def stage_completion_status(stage_name: str, *, existing_final_status: str | None) -> tuple[str, str | None]:

--- a/tests/runtime/test_route_execution.py
+++ b/tests/runtime/test_route_execution.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 from forgeflow_runtime.orchestrator import RuntimeViolation, load_runtime_policy, run_route
-from forgeflow_runtime.route_execution import route_entry_decision, route_iteration_stages
+from forgeflow_runtime.route_execution import build_route_result, route_entry_decision, route_iteration_stages
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -15,6 +15,29 @@ def test_route_iteration_stages_starts_at_resume_index() -> None:
     route = ["clarify", "plan", "execute", "quality-review", "finalize"]
 
     assert route_iteration_stages(route, 2) == ["execute", "quality-review", "finalize"]
+
+
+def test_build_route_result_uses_plan_ledger_progress_when_present() -> None:
+    run_state = {
+        "current_stage": "finalize",
+        "status": "completed",
+        "completed_gates": ["stale-run-state-gate"],
+        "retries": {"execute": 1},
+    }
+    plan_ledger = {
+        "completed_gates": ["clarification_complete", "ready_to_finalize"],
+        "retries": {"execute": 2, "quality-review": 1},
+    }
+
+    result = build_route_result(run_state, plan_ledger)
+
+    assert result == {
+        "current_stage": "finalize",
+        "status": "completed",
+        "completed_gates": ["clarification_complete", "ready_to_finalize"],
+        "retries": {"execute": 2, "quality-review": 1},
+    }
+    assert run_state["completed_gates"] == ["stale-run-state-gate"]
 
 
 def test_route_entry_decision_selects_new_route() -> None:


### PR DESCRIPTION
## Summary
- Extract route result construction into route_execution.build_route_result.
- Keep run_route behavior unchanged while centralizing plan-ledger/run-state result precedence.
- Add focused seam test proving plan-ledger progress wins without mutating run-state.

## Verification
- pytest tests/runtime/test_route_execution.py::test_build_route_result_uses_plan_ledger_progress_when_present tests/runtime/test_route_execution.py -q
- pytest -q
- git diff --check
- make validate

Closes #55
