### PR TITLE
Fix ForgeFlow review gate workflow

### DIFF
--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -207,6 +207,7 @@ Do not code during planning unless the user explicitly asks for a tiny small-rou
 - Do not ask for 계획 내용 재승인 when the plan is executable; the agent owns decomposition.
 - Do stop before crossing the `plan → run` stage boundary, because execution is a separate stage.
 - End with a closed next-stage question such as `계획은 여기까지 확정됐습니다. 다음 스텝으로 `/forgeflow:run`을 진행하시겠습니까? (y/n)`.
+- Do not invoke `/forgeflow:run`, the Skill tool, or any execution tool in the same assistant turn after asking the closed next-stage question. The next assistant turn may proceed only after an explicit user approval such as `y`, `yes`, `진행`, or `실행`.
 - Bad: `계획 확정. run 직행.`
 - Bad: `내가 계획을 세워?`
 - Good: `아니요. 계획은 내가 세운다. 아래처럼 진행.`

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -131,6 +131,8 @@ Review evidence is not fan fiction.
    - If performance was touched, was the bottleneck measured before and after the change?
 6. Classify findings: critical, major, minor, info.
 7. Return a clear verdict unless the user asked for a narrower output.
+8. If verdict is `changes_requested` or `blocked`, update `run-state.json` in the active task directory when present so status reflects the review gate, for example `review_blocked`, and record the review artifact path/evidence. Do not leave the task looking ship-ready just because implementation steps completed.
+9. Do not call `/forgeflow:ship` unless `verdict=approved`, `safe_for_next_stage=true`, and `open_blockers=[]` are all true in the current `review-report.json`.
 
 Do not merge spec-review and quality-review for large/high-risk work.
 

--- a/skills/run/SKILL.md
+++ b/skills/run/SKILL.md
@@ -95,8 +95,10 @@ Worker self-report is not approval. `/forgeflow:review` still has to happen.
 ## UX guardrails
 
 - Treat the latest executable brief/plan as sufficient authority only after the user has approved entering `/forgeflow:run`.
+- If `/forgeflow:run` was reached without explicit user approval after the previous stage-boundary question, stop immediately and ask for approval instead of editing files. Do not infer approval from the agent's own prior question.
 - 이미 승인된 run scope 안에서는 반복적으로 계획을 다시 허락받지 않는다.
 - Do not pause just to reconfirm the same plan before editing files.
 - Only bounce back to `/forgeflow:clarify` or `/forgeflow:specify` when scope genuinely changed or a blocker invalidates the current brief/plan.
+- When the user asks to fix review findings, treat that as approval to enter a fix loop for the current review scope: read the latest `review-report.json`, fix only current `open_blockers`/major findings, re-run focused verification, and update `review-report.json` before claiming the fix loop is complete. The updated `open_blockers` must reflect the remaining current blockers, not stale blockers from the previous review.
 - Bad: `승인된 계획대로 실행하겠습니다.`만 말하고 대기.
 - Good: 바로 수정/검증을 시작하고 evidence를 남긴다.

--- a/tests/test_forgeflow_ux_contract.py
+++ b/tests/test_forgeflow_ux_contract.py
@@ -28,9 +28,24 @@ def test_plan_and_run_skills_separate_stage_boundary_approval_from_reapproval() 
 
     assert "계획 내용 재승인" in plan_text
     assert "다음 스텝으로 `/forgeflow:run`을 진행하시겠습니까? (y/n)" in plan_text
+    assert "Do not invoke `/forgeflow:run`, the Skill tool, or any execution tool in the same assistant turn" in plan_text
     assert "계획 확정. 바로 run." not in plan_text
     assert "이미 승인된 run scope 안에서는" in run_text
     assert "Do not pause just to reconfirm the same plan before editing files." in run_text
+    assert "If `/forgeflow:run` was reached without explicit user approval" in run_text
+
+
+def test_review_changes_requested_blocks_run_state_and_fix_loop() -> None:
+    review_text = (ROOT / "skills" / "review" / "SKILL.md").read_text(encoding="utf-8")
+    run_text = (ROOT / "skills" / "run" / "SKILL.md").read_text(encoding="utf-8")
+
+    assert "If verdict is `changes_requested` or `blocked`, update `run-state.json`" in review_text
+    assert "review_blocked" in review_text
+    assert "Do not call `/forgeflow:ship` unless `verdict=approved`" in review_text
+    assert "When the user asks to fix review findings" in run_text
+    assert "re-run focused verification" in run_text
+    assert "update `review-report.json`" in run_text
+    assert "open_blockers` must reflect the remaining current blockers" in run_text
 
 
 def test_canonical_workflow_skills_are_artifact_first_by_default() -> None:


### PR DESCRIPTION
## Summary
- Prevent plan from invoking run in the same turn after asking for stage-boundary approval
- Make run stop if it was entered without explicit user approval
- Require review failures to update run-state and block ship
- Define the review-fix loop: fix current blockers, rerun focused verification, and refresh review-report

## Test Plan
- python3 -m pytest tests/test_forgeflow_ux_contract.py -q
- python3 scripts/validate_generated.py
- python3 scripts/validate_skill_contracts.py
- python3 -m pytest tests/test_forgeflow_ux_contract.py tests/test_plugin_skill_contracts.py -q
- python3 -m pytest -q

Note: make setup/validate could not run because python3-venv is unavailable in this WSL image.