### PR TITLE
Release ForgeFlow 0.1.26

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Artifact-first delivery harness for AI coding agents with explicit stages, gates, evidence, and independent review",
-    "version": "0.1.25"
+    "version": "0.1.26"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "forgeflow",
   "description": "Artifact-first delivery harness for AI coding agents: staged workflow, gates, evidence, and independent review",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "author": {
     "name": "gimso2x",
     "url": "https://github.com/gimso2x"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forgeflow",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "description": "Artifact-first delivery harness for AI coding agents: staged workflow, gates, evidence, and independent review",
   "author": {
     "name": "gimso2x",


### PR DESCRIPTION
## Summary
- Bump Claude/Codex plugin metadata from 0.1.25 to 0.1.26 so Claude Code plugin update can pick up the review-gate workflow fixes from PR #58.

## Test Plan
- python3 scripts/check_plugin_versions.py
- python3 scripts/validate_generated.py
- python3 scripts/validate_skill_contracts.py
- python3 -m pytest tests/test_forgeflow_ux_contract.py tests/test_plugin_manifests.py -q