### PR TITLE
Require incremental run-state step updates

### DIFF
--- a/skills/run/SKILL.md
+++ b/skills/run/SKILL.md
@@ -40,6 +40,8 @@ Use this skill to execute the selected ForgeFlow route.
 
 Default to **artifact-first mode**. Run should update `run-state.json` before and after code changes, and keep execution evidence in the active task directory unless the user explicitly asks for a dry run, exact-output response, or no-write simulation.
 
+Step state must be incremental, not a final recap. Each plan step must move through `in_progress` before `completed`, and the agent must update `run-state.json` immediately when starting and finishing each step. Example: `step-1: pending → in_progress → completed`, then `step-2: pending → in_progress → completed`. Do not batch-mark all steps as `completed` only at the end. If a step cannot finish, mark it `blocked` or `failed` with evidence instead of leaving the last known state ambiguous.
+
 Canonical writable location:
 
 - explicit task directory provided by the user, or

--- a/tests/test_forgeflow_ux_contract.py
+++ b/tests/test_forgeflow_ux_contract.py
@@ -69,6 +69,15 @@ def test_canonical_workflow_skills_are_artifact_first_by_default() -> None:
     assert "Preserve artifacts/evidence instead of burying them in chat." in ship
 
 
+def test_run_skill_requires_incremental_step_state_updates() -> None:
+    run = (ROOT / "skills" / "run" / "SKILL.md").read_text(encoding="utf-8")
+
+    assert "Each plan step must move through `in_progress` before `completed`" in run
+    assert "update `run-state.json` immediately when starting and finishing each step" in run
+    assert "Do not batch-mark all steps as `completed` only at the end" in run
+    assert "step-1: pending → in_progress → completed" in run
+
+
 def test_canonical_prompts_require_stage_boundary_approval_without_reapproval_loops() -> None:
     coordinator = (ROOT / "prompts" / "canonical" / "coordinator.md").read_text(encoding="utf-8")
     planner = (ROOT / "prompts" / "canonical" / "planner.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Clarify that /forgeflow:run must update run-state.json as each plan step starts and finishes.
- Add UX contract coverage so agents do not batch-mark all steps completed only at the end.

## Test Plan
- python3 -m pytest tests/test_forgeflow_ux_contract.py -q
- python3 scripts/validate_skill_contracts.py
- python3 scripts/validate_generated.py