### PR TITLE
[codex] Fix home path context validation

### DIFF
--- a/scripts/validate_context_paths.py
+++ b/scripts/validate_context_paths.py
@@ -52,7 +52,7 @@ EXAMPLE_REF_CONTAINS = (
 )
 
 PATH_REF_RE = re.compile(
-    r"(?<![A-Za-z0-9_./<>{}-])"
+    r"(?<![A-Za-z0-9_./<>{}~-])"
     r"((?:\./|/|\.[A-Za-z0-9_-]+/|[A-Za-z0-9_]+/)"
     r"[A-Za-z0-9_./-]+\."
     r"(?:json|yaml|yml|toml|tsx|jsx|py|ts|js|md|sql|html|css|sh|go|rs|java|kt|rb|php))"


### PR DESCRIPTION
## Summary
- Fix context path validation so home-directory paths like ~/.agents/plugins/marketplace.json are not misread as repo-local absolute paths.

## Validation
- wsl python3 scripts/validate_context_paths.py