### PR TITLE
feat: wire specialist agents into runtime (fixes #135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `validate_and_migrate` mode: 0.1 artifacts silently upgraded on load.
 - Implement `_migrate_0_1_to_0_2`: brief gains specialist fields, review-report gains review_roles.
 
+## [0.8.0] - 2026-05-13
+
+### Added
+
+- Wire specialist agents into runtime execution path (#135).
+- `DOMAIN_TO_STAGE` mapping: security→security-review, backend→backend-execute, frontend→frontend-execute, infra→infra-execute, ux→ux-review, perf→perf-review.
+- `specialists_from_brief()` now handles both domain names and stage names.
+- 6 specialist prompt files in `prompts/canonical/` (security-reviewer, ux-reviewer, perf-reviewer, frontend-worker, backend-worker, infra-worker).
+- 48 TDD tests for specialist wiring in `tests/runtime/test_specialist_wiring.py`.
+- Real plugin E2E harness in `scripts/real_plugin_e2e.py`.
+
+### Changed
+
+- `ROLE_TO_FILENAME` now covers 11 roles (added 6 specialist agents) in both `generator.py` and `preset_resolver.py`.
+- Codex `plugin.json` supports 6 specialist agents in `supports_roles` and `agents`.
+- `operator_routing.py` gains `_normalise_specialist()` for domain→stage conversion.
+- Route terminology cleanup: "high risk" → "high" in docs.
+
+### Stats
+
+- **1541 tests passed**, 0 failed.
+
 ## [0.7.5] - 2026-05-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 AI coding agent가 채팅 기억에 의존하지 않고, **명시적인 artifact, gate, evidence, 독립 review**로 작업하게 만드는 artifact-first delivery harness. Claude Code와 Codex에서 같은 workflow를 사용합니다.
 
-현재 릴리즈: **v0.7.4**
+현재 릴리즈: **v0.8.0**
 
 ## 누가 왜 쓰나
 
@@ -94,6 +94,7 @@ Windows PowerShell:
 - **Artifact model** — brief, plan, run-state, review-report 등 모든 단계가 검증 가능한 JSON artifact를 생성합니다 → [docs/artifact-model.md](docs/artifact-model.md)
 - **Review model** — evidence 기반 독립 review contract. 작성자와 검토자 분리 → [docs/review-model.md](docs/review-model.md)
 - **Route model (small/medium/high)** — 작업 위험도와 복잡도에 따라 실행 경로를 자동 선택합니다 → [docs/operator-shell.md](docs/operator-shell.md)
+- **2-axis specialist selection** — route 축(작업 크기)과 spec 축(전문 에이전트)이 독립 작동합니다. security/backend/frontend/infra/ux/perf 6개 도메인 → [docs/workflow.md](docs/workflow.md)
 - **Adapter boundary** — Claude Code와 Codex에서 동일한 workflow를 보장하는 adapter 계층 → [docs/adapter-model.md](docs/adapter-model.md)
 
 ## 문제 해결

--- a/adapters/targets/codex/plugin.json
+++ b/adapters/targets/codex/plugin.json
@@ -16,7 +16,13 @@
     "planner",
     "worker",
     "spec-reviewer",
-    "quality-reviewer"
+    "quality-reviewer",
+    "security-reviewer",
+    "ux-reviewer",
+    "perf-reviewer",
+    "frontend-worker",
+    "backend-worker",
+    "infra-worker"
   ],
   "keywords": [
     "ai-agents",
@@ -31,7 +37,13 @@
     "adapters/targets/codex/agents/forgeflow-planner.md",
     "adapters/targets/codex/agents/forgeflow-worker.md",
     "adapters/targets/codex/agents/forgeflow-spec-reviewer.md",
-    "adapters/targets/codex/agents/forgeflow-quality-reviewer.md"
+    "adapters/targets/codex/agents/forgeflow-quality-reviewer.md",
+    "adapters/targets/codex/agents/forgeflow-security-reviewer.md",
+    "adapters/targets/codex/agents/forgeflow-ux-reviewer.md",
+    "adapters/targets/codex/agents/forgeflow-perf-reviewer.md",
+    "adapters/targets/codex/agents/forgeflow-frontend-worker.md",
+    "adapters/targets/codex/agents/forgeflow-backend-worker.md",
+    "adapters/targets/codex/agents/forgeflow-infra-worker.md"
   ],
   "rules": [
     "adapters/targets/codex/rules/forgeflow-nextjs-worker.mdc"

--- a/docs/concepts/route-model.md
+++ b/docs/concepts/route-model.md
@@ -34,7 +34,7 @@ forgeflow init --task-id my-task --objective "..." --risk high
 
 ## Architecture 패턴
 
-high risk 작업은 자동으로 더 강건한 실행 패턴을 씁니다:
+**high** 라우트 작업은 자동으로 더 강건한 실행 패턴을 씁니다:
 
 - **fan-out/fan-in + producer-reviewer**: security, migration, refactor, architecture
 - **pipeline + producer-reviewer**: bug, fix, qa, test, regression

--- a/forgeflow_runtime/generator.py
+++ b/forgeflow_runtime/generator.py
@@ -29,6 +29,13 @@ ROLE_TO_FILENAME = {
     "worker": "worker.md",
     "spec-reviewer": "spec-reviewer.md",
     "quality-reviewer": "quality-reviewer.md",
+    # specialist agents (on-demand via brief.required_specialists)
+    "security-reviewer": "security-reviewer.md",
+    "ux-reviewer": "ux-reviewer.md",
+    "perf-reviewer": "perf-reviewer.md",
+    "frontend-worker": "frontend-worker.md",
+    "backend-worker": "backend-worker.md",
+    "infra-worker": "infra-worker.md",
 }
 
 DEFAULT_TOKEN_BUDGET = {

--- a/forgeflow_runtime/operator_routing.py
+++ b/forgeflow_runtime/operator_routing.py
@@ -33,6 +33,28 @@ RISK_TO_ROUTE: dict[str, str] = {
     "high": "high",
 }
 
+# Domain vocabulary → canonical stage name mapping.
+# Brief authors use short domain names (e.g. "security", "backend");
+# the runtime maps them to the stage names recognised by STAGE_ROLE_MAP.
+DOMAIN_TO_STAGE: dict[str, str] = {
+    "security": "security-review",
+    "backend": "backend-execute",
+    "frontend": "frontend-execute",
+    "infra": "infra-execute",
+    "ux": "ux-review",
+    "perf": "perf-review",
+}
+
+
+def _normalise_specialist(name: str) -> str | None:
+    """Map a brief domain name or canonical stage name to a valid stage key.
+
+    Returns *None* when *name* is not a recognised specialist identifier.
+    """
+    if name in STAGE_ROLE_MAP:
+        return name
+    return DOMAIN_TO_STAGE.get(name)
+
 
 def role_for_stage(
     stage: str,
@@ -53,7 +75,11 @@ def role_for_stage(
 
 
 def specialists_from_brief(task_dir: Path) -> list[str]:
-    """Return required_specialists from brief.json, or empty list."""
+    """Return required_specialists from brief.json, or empty list.
+
+    Accepts both canonical stage names (``security-review``) and short
+    domain names (``security``).  Unrecognised values are silently dropped.
+    """
     brief_path = task_dir / "brief.json"
     if not brief_path.exists():
         return []
@@ -61,7 +87,12 @@ def specialists_from_brief(task_dir: Path) -> list[str]:
     specialists = payload.get("required_specialists")
     if not isinstance(specialists, list):
         return []
-    return [s for s in specialists if s in STAGE_ROLE_MAP]
+    resolved: list[str] = []
+    for name in specialists:
+        stage = _normalise_specialist(str(name))
+        if stage is not None:
+            resolved.append(stage)
+    return resolved
 
 
 def route_rank(

--- a/forgeflow_runtime/preset_resolver.py
+++ b/forgeflow_runtime/preset_resolver.py
@@ -29,6 +29,13 @@ ROLE_TO_FILENAME: dict[str, str] = {
     "worker": "worker.md",
     "spec-reviewer": "spec-reviewer.md",
     "quality-reviewer": "quality-reviewer.md",
+    # specialist agents (on-demand via brief.required_specialists)
+    "security-reviewer": "security-reviewer.md",
+    "ux-reviewer": "ux-reviewer.md",
+    "perf-reviewer": "perf-reviewer.md",
+    "frontend-worker": "frontend-worker.md",
+    "backend-worker": "backend-worker.md",
+    "infra-worker": "infra-worker.md",
 }
 
 COMPOSITION_SUFFIXES: dict[str, str] = {

--- a/prompts/canonical/backend-worker.md
+++ b/prompts/canonical/backend-worker.md
@@ -1,0 +1,46 @@
+---
+name: forgeflow-backend-worker
+description: Backend specialist executor — APIs, data models, business logic.
+---
+
+# Forgeflow Backend Worker (Codex)
+
+You are a specialist executor activated on-demand via `brief.required_specialists`.
+Execute only work within your domain. Refer cross-domain tasks to the coordinator.
+
+## Execution checklist
+- API contracts match spec (request/response schemas, status codes).
+- Database migrations are reversible and non-destructive.
+- Business logic is decoupled from transport layer.
+- Error handling covers all documented failure modes.
+- Logging includes structured context for debugging.
+- Data validation happens at service boundaries.
+
+## Execution rules
+
+- Execute only within brief/plan scope. Deviations go to `decision-log`.
+- Update `run-state` after significant changes.
+- Write evidence for every task completion claim.
+
+## Severity guide
+- P0: data loss, broken API contract, unhandled critical error.
+- P1: missing validation, inconsistent error format, migration risk.
+- P2: minor code style, missing docstring, suboptimal query.
+
+## Evidence requirements
+- API endpoint path and changed parameters.
+- Migration file and rollback verification.
+- Test output proving behavior change.
+
+## Output contract
+Report task completion with evidence refs in `run-state`. Log decisions to `decision-log`.
+
+## 출력 언어
+
+모든 자유 텍스트(findings, evidence_refs, missing_evidence, next_action 등)는 한국어로 작성한다.
+스키마 필드명과 enum 값(verdict, review_type 등)은 영어 그대로 유지하되, 사람이 읽는 설명은 한국어로.
+
+## Human-context triage
+- AI review/execution comments are not automatic truth. Re-check each finding against diff, artifacts, acceptance criteria, and evidence refs.
+- Drop or downgrade weak/low-impact comments instead of turning them into blockers.
+- Leave findings in `review-report.json` so a human can make the final project-context judgment.

--- a/prompts/canonical/frontend-worker.md
+++ b/prompts/canonical/frontend-worker.md
@@ -1,0 +1,46 @@
+---
+name: forgeflow-frontend-worker
+description: Frontend specialist executor — UI components, state management, styling.
+---
+
+# Forgeflow Frontend Worker (Codex)
+
+You are a specialist executor activated on-demand via `brief.required_specialists`.
+Execute only work within your domain. Refer cross-domain tasks to the coordinator.
+
+## Execution checklist
+- Components follow project design system and naming conventions.
+- State management is consistent (props vs local vs global).
+- Styles are scoped and do not leak across components.
+- Responsive breakpoints are handled for target viewports.
+- Client-side routing and navigation match spec.
+- Accessibility attributes (aria-*, role, tabIndex) are correct.
+
+## Execution rules
+
+- Execute only within brief/plan scope. Deviations go to `decision-log`.
+- Update `run-state` after significant changes.
+- Write evidence for every task completion claim.
+
+## Severity guide
+- P0: broken render, state corruption, inaccessible component.
+- P1: style regression, missing responsive case, incorrect props.
+- P2: minor visual inconsistency, unused imports.
+
+## Evidence requirements
+- Component file path and line references.
+- Before/after screenshot comparison for visual changes.
+- Console errors or warnings observed during testing.
+
+## Output contract
+Report task completion with evidence refs in `run-state`. Log decisions to `decision-log`.
+
+## 출력 언어
+
+모든 자유 텍스트(findings, evidence_refs, missing_evidence, next_action 등)는 한국어로 작성한다.
+스키마 필드명과 enum 값(verdict, review_type 등)은 영어 그대로 유지하되, 사람이 읽는 설명은 한국어로.
+
+## Human-context triage
+- AI review/execution comments are not automatic truth. Re-check each finding against diff, artifacts, acceptance criteria, and evidence refs.
+- Drop or downgrade weak/low-impact comments instead of turning them into blockers.
+- Leave findings in `review-report.json` so a human can make the final project-context judgment.

--- a/prompts/canonical/infra-worker.md
+++ b/prompts/canonical/infra-worker.md
@@ -1,0 +1,46 @@
+---
+name: forgeflow-infra-worker
+description: Infrastructure specialist executor — deployment, IaC, config, networking.
+---
+
+# Forgeflow Infra Worker (Codex)
+
+You are a specialist executor activated on-demand via `brief.required_specialists`.
+Execute only work within your domain. Refer cross-domain tasks to the coordinator.
+
+## Execution checklist
+- Infrastructure changes are reproducible via IaC (Terraform, Pulumi, etc.).
+- Secrets are injected via vault/env, not committed.
+- Network rules follow least-privilege (no 0.0.0.0/0 defaults).
+- Rollback procedure is documented and tested.
+- Resource limits (CPU, memory, disk) are explicitly set.
+- Health checks and monitoring are configured for new services.
+
+## Execution rules
+
+- Execute only within brief/plan scope. Deviations go to `decision-log`.
+- Update `run-state` after significant changes.
+- Write evidence for every task completion claim.
+
+## Severity guide
+- P0: security group open to world, secret committed, no rollback.
+- P1: missing health check, no resource limits, fragile deployment order.
+- P2: minor config drift, missing tag/label, verbose logging.
+
+## Evidence requirements
+- IaC file path and changed resource.
+- Diff of network/security rules.
+- Deployment logs showing success/failure.
+
+## Output contract
+Report task completion with evidence refs in `run-state`. Log decisions to `decision-log`.
+
+## 출력 언어
+
+모든 자유 텍스트(findings, evidence_refs, missing_evidence, next_action 등)는 한국어로 작성한다.
+스키마 필드명과 enum 값(verdict, review_type 등)은 영어 그대로 유지하되, 사람이 읽는 설명은 한국어로.
+
+## Human-context triage
+- AI review/execution comments are not automatic truth. Re-check each finding against diff, artifacts, acceptance criteria, and evidence refs.
+- Drop or downgrade weak/low-impact comments instead of turning them into blockers.
+- Leave findings in `review-report.json` so a human can make the final project-context judgment.

--- a/prompts/canonical/perf-reviewer.md
+++ b/prompts/canonical/perf-reviewer.md
@@ -1,0 +1,49 @@
+---
+name: forgeflow-perf-reviewer
+description: Performance specialist reviewer — latency, throughput, memory, scalability.
+---
+
+# Forgeflow Perf Reviewer (Codex)
+
+You are a specialist reviewer activated on-demand via `brief.required_specialists`.
+Judge only against your specialist domain. Leave non-domain findings to other reviewers.
+
+## Review checklist
+- No N+1 queries or unbatched network calls in hot paths.
+- Large lists use pagination or virtualization.
+- Expensive computations are memoized or offloaded.
+- Assets are optimized (image formats, code splitting, lazy loading).
+- Database queries have appropriate indexes.
+- Memory allocation patterns avoid unnecessary copies or retention.
+- Caching strategy is documented and cache invalidation is correct.
+- Load-sensitive paths have documented SLOs or budgets.
+
+## Read-only enforcement
+
+review 단계는 **읽기 전용 검증**이다. 코드를 수정하지 않는다.
+
+- `Read`, `Bash`(검증용), `Grep`만 사용한다. `Write`, `Edit`는 사용하지 않는다.
+- 수정이 필요한 경우 `review-report.json`의 `findings`에 기록한다.
+
+## Severity guide
+- P0: O(n²) in request path, memory leak, unbounded growth.
+- P1: missing pagination, redundant computation, unoptimized assets.
+- P2: minor inefficiency, premature optimization suggestion.
+
+## Evidence requirements
+- Benchmark numbers or profiling data for P0/P1.
+- Specific function/endpoint and expected vs actual behavior.
+- Comparison before/after where applicable.
+
+## Output contract
+Return findings sorted by severity. If clean, say `PASS` and list evidence. Write `review-report.json` with `review_type` matching your specialist domain.
+
+## 출력 언어
+
+모든 자유 텍스트(findings, evidence_refs, missing_evidence, next_action 등)는 한국어로 작성한다.
+스키마 필드명과 enum 값(verdict, review_type 등)은 영어 그대로 유지하되, 사람이 읽는 설명은 한국어로.
+
+## Human-context triage
+- AI review/execution comments are not automatic truth. Re-check each finding against diff, artifacts, acceptance criteria, and evidence refs.
+- Drop or downgrade weak/low-impact comments instead of turning them into blockers.
+- Leave findings in `review-report.json` so a human can make the final project-context judgment.

--- a/prompts/canonical/security-reviewer.md
+++ b/prompts/canonical/security-reviewer.md
@@ -1,0 +1,49 @@
+---
+name: forgeflow-security-reviewer
+description: Security specialist reviewer — auth, crypto, input validation, secrets.
+---
+
+# Forgeflow Security Reviewer (Codex)
+
+You are a specialist reviewer activated on-demand via `brief.required_specialists`.
+Judge only against your specialist domain. Leave non-domain findings to other reviewers.
+
+## Review checklist
+- Authentication/authorization flows are correct and complete.
+- No hardcoded secrets, API keys, or credentials in code or config.
+- All user input is validated, sanitized, and bounds-checked.
+- Cryptographic operations use current standard algorithms (no MD5, SHA1 for security).
+- SQL injection, XSS, CSRF, and SSRF vectors are addressed.
+- Error messages do not leak sensitive internal state.
+- Dependencies have no known critical CVEs.
+- File permissions and access controls follow least-privilege.
+
+## Read-only enforcement
+
+review 단계는 **읽기 전용 검증**이다. 코드를 수정하지 않는다.
+
+- `Read`, `Bash`(검증용), `Grep`만 사용한다. `Write`, `Edit`는 사용하지 않는다.
+- 수정이 필요한 경우 `review-report.json`의 `findings`에 기록한다.
+
+## Severity guide
+- P0: exploitable vulnerability, leaked secrets, broken auth.
+- P1: weak input validation, outdated crypto, missing rate limiting.
+- P2: verbose errors, minor misconfiguration, missing security headers.
+
+## Evidence requirements
+- Exact file:line for each finding.
+- Proof-of-concept or attack vector description for P0/P1.
+- Reference to CWE or OWASP category where applicable.
+
+## Output contract
+Return findings sorted by severity. If clean, say `PASS` and list evidence. Write `review-report.json` with `review_type` matching your specialist domain.
+
+## 출력 언어
+
+모든 자유 텍스트(findings, evidence_refs, missing_evidence, next_action 등)는 한국어로 작성한다.
+스키마 필드명과 enum 값(verdict, review_type 등)은 영어 그대로 유지하되, 사람이 읽는 설명은 한국어로.
+
+## Human-context triage
+- AI review/execution comments are not automatic truth. Re-check each finding against diff, artifacts, acceptance criteria, and evidence refs.
+- Drop or downgrade weak/low-impact comments instead of turning them into blockers.
+- Leave findings in `review-report.json` so a human can make the final project-context judgment.

--- a/prompts/canonical/ux-reviewer.md
+++ b/prompts/canonical/ux-reviewer.md
@@ -1,0 +1,49 @@
+---
+name: forgeflow-ux-reviewer
+description: UX specialist reviewer — usability, accessibility, user flow consistency.
+---
+
+# Forgeflow Ux Reviewer (Codex)
+
+You are a specialist reviewer activated on-demand via `brief.required_specialists`.
+Judge only against your specialist domain. Leave non-domain findings to other reviewers.
+
+## Review checklist
+- User flows are intuitive and match mental models.
+- Interactive elements have visible focus states and ARIA labels.
+- Color contrast meets WCAG 2.1 AA (4.5:1 for text).
+- Error states provide actionable recovery guidance.
+- Loading/empty/error states are handled for all data-driven views.
+- Navigation is consistent and predictable.
+- Touch targets meet minimum 44x44px on mobile.
+- Forms validate inline with clear messages near the field.
+
+## Read-only enforcement
+
+review 단계는 **읽기 전용 검증**이다. 코드를 수정하지 않는다.
+
+- `Read`, `Bash`(검증용), `Grep`만 사용한다. `Write`, `Edit`는 사용하지 않는다.
+- 수정이 필요한 경우 `review-report.json`의 `findings`에 기록한다.
+
+## Severity guide
+- P0: inaccessible to screen readers, broken critical flow.
+- P1: inconsistent patterns, missing error states, poor mobile UX.
+- P2: minor spacing issues, copy inconsistency, polish gaps.
+
+## Evidence requirements
+- Screenshot or component reference for each finding.
+- WCAG criterion reference for accessibility issues.
+- User flow step where the issue occurs.
+
+## Output contract
+Return findings sorted by severity. If clean, say `PASS` and list evidence. Write `review-report.json` with `review_type` matching your specialist domain.
+
+## 출력 언어
+
+모든 자유 텍스트(findings, evidence_refs, missing_evidence, next_action 등)는 한국어로 작성한다.
+스키마 필드명과 enum 값(verdict, review_type 등)은 영어 그대로 유지하되, 사람이 읽는 설명은 한국어로.
+
+## Human-context triage
+- AI review/execution comments are not automatic truth. Re-check each finding against diff, artifacts, acceptance criteria, and evidence refs.
+- Drop or downgrade weak/low-impact comments instead of turning them into blockers.
+- Leave findings in `review-report.json` so a human can make the final project-context judgment.

--- a/tests/runtime/test_specialist_wiring.py
+++ b/tests/runtime/test_specialist_wiring.py
@@ -1,0 +1,189 @@
+"""TDD failing tests for Issue #135 — specialist agent runtime wiring.
+
+These tests assert that spec-based specialist agents (security, backend,
+frontend, infra, ux, perf) are fully wired into the runtime execution path:
+  1. generator ROLE_TO_FILENAME mapping
+  2. plugin.json manifest (agents + supports_roles)
+  3. specialists_from_brief() domain→stage conversion
+  4. operator_routing specialist role resolution
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from forgeflow_runtime import generator as gen_mod
+from forgeflow_runtime.operator_routing import (
+    STAGE_ROLE_MAP,
+    role_for_stage,
+    specialists_from_brief,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_JSON = REPO_ROOT / "adapters" / "targets" / "codex" / "plugin.json"
+AGENTS_DIR = REPO_ROOT / "adapters" / "targets" / "codex" / "agents"
+
+# ── 1. generator ROLE_TO_FILENAME specialist mapping ───────────────────
+
+SPECIALIST_ROLES = [
+    "security-reviewer",
+    "ux-reviewer",
+    "perf-reviewer",
+    "frontend-worker",
+    "backend-worker",
+    "infra-worker",
+]
+
+
+@pytest.mark.parametrize("role", SPECIALIST_ROLES)
+def test_role_to_filename_has_specialist(role: str) -> None:
+    """Each specialist role must have a ROLE_TO_FILENAME entry."""
+    assert role in gen_mod.ROLE_TO_FILENAME, (
+        f"ROLE_TO_FILENAME missing specialist role: {role}"
+    )
+
+
+@pytest.mark.parametrize("role", SPECIALIST_ROLES)
+def test_role_to_filename_points_to_existing_file(role: str) -> None:
+    """ROLE_TO_FILENAME entry must point to a file that actually exists in prompts/canonical/."""
+    filename = gen_mod.ROLE_TO_FILENAME.get(role)
+    assert filename is not None, f"ROLE_TO_FILENAME has no entry for {role}"
+    # specialist agent md files live in agents dir, prompt files in canonical
+    # At minimum the referenced file must resolve
+    prompt_path = gen_mod.CANONICAL_PROMPT_DIR / filename
+    agents_path = AGENTS_DIR / f"forgeflow-{role}.md"
+    assert prompt_path.exists() or agents_path.exists(), (
+        f"Neither prompt file ({prompt_path}) nor agent file ({agents_path}) exists for {role}"
+    )
+
+
+# ── 2. plugin.json manifest ───────────────────────────────────────────
+
+def test_plugin_json_loads() -> None:
+    """plugin.json must be valid JSON."""
+    payload = json.loads(PLUGIN_JSON.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+
+
+@pytest.mark.parametrize("role", SPECIALIST_ROLES)
+def test_plugin_json_supports_specialist_roles(role: str) -> None:
+    """plugin.json supports_roles must list all specialist roles."""
+    payload = json.loads(PLUGIN_JSON.read_text(encoding="utf-8"))
+    supported = payload.get("supports_roles", [])
+    assert role in supported, (
+        f"plugin.json supports_roles missing: {role} (has: {supported})"
+    )
+
+
+@pytest.mark.parametrize("role", SPECIALIST_ROLES)
+def test_plugin_json_agents_list_specialists(role: str) -> None:
+    """plugin.json agents must reference specialist agent md files."""
+    payload = json.loads(PLUGIN_JSON.read_text(encoding="utf-8"))
+    agents = payload.get("agents", [])
+    expected = f"adapters/targets/codex/agents/forgeflow-{role}.md"
+    assert expected in agents, (
+        f"plugin.json agents missing: {expected} (has: {agents})"
+    )
+
+
+@pytest.mark.parametrize("role", SPECIALIST_ROLES)
+def test_specialist_agent_md_file_exists(role: str) -> None:
+    """Each specialist agent markdown file must physically exist."""
+    agent_file = AGENTS_DIR / f"forgeflow-{role}.md"
+    assert agent_file.exists(), f"Missing agent file: {agent_file}"
+
+
+# ── 3. specialists_from_brief() domain→stage conversion ────────────────
+
+DOMAIN_VOCABULARY = {
+    "security": "security-review",
+    "backend": "backend-execute",
+    "frontend": "frontend-execute",
+    "infra": "infra-execute",
+    "ux": "ux-review",
+    "perf": "perf-review",
+}
+
+
+def test_specialists_from_brief_with_domain_names(tmp_path: Path) -> None:
+    """brief.json with domain names (security, backend, ...) must resolve to stages."""
+    brief = {"required_specialists": ["security", "backend"]}
+    (tmp_path / "brief.json").write_text(json.dumps(brief), encoding="utf-8")
+
+    result = specialists_from_brief(tmp_path)
+    # Should map domain names to stage names recognized by STAGE_ROLE_MAP
+    assert "security-review" in result or "security" in result, (
+        f"specialists_from_brief did not resolve 'security': got {result}"
+    )
+    assert "backend-execute" in result or "backend" in result, (
+        f"specialists_from_brief did not resolve 'backend': got {result}"
+    )
+
+
+def test_specialists_from_brief_with_stage_names(tmp_path: Path) -> None:
+    """brief.json with stage names (security-review, backend-execute) must pass through."""
+    brief = {"required_specialists": ["security-review", "backend-execute"]}
+    (tmp_path / "brief.json").write_text(json.dumps(brief), encoding="utf-8")
+
+    result = specialists_from_brief(tmp_path)
+    assert "security-review" in result
+    assert "backend-execute" in result
+
+
+def test_specialists_from_brief_ignores_unknown(tmp_path: Path) -> None:
+    """brief.json with unknown specialist names must filter them out."""
+    brief = {"required_specialists": ["security", "nonexistent"]}
+    (tmp_path / "brief.json").write_text(json.dumps(brief), encoding="utf-8")
+
+    result = specialists_from_brief(tmp_path)
+    assert "nonexistent" not in result
+
+
+def test_specialists_from_brief_no_file(tmp_path: Path) -> None:
+    """Missing brief.json returns empty list."""
+    result = specialists_from_brief(tmp_path)
+    assert result == []
+
+
+# ── 4. operator_routing specialist role resolution ─────────────────────
+
+SPECIALIST_STAGE_ROLE_PAIRS = [
+    ("security-review", "security-reviewer"),
+    ("ux-review", "ux-reviewer"),
+    ("perf-review", "perf-reviewer"),
+    ("frontend-execute", "frontend-worker"),
+    ("backend-execute", "backend-worker"),
+    ("infra-execute", "infra-worker"),
+]
+
+
+@pytest.mark.parametrize("stage,expected_role", SPECIALIST_STAGE_ROLE_PAIRS)
+def test_stage_role_map_specialists(stage: str, expected_role: str) -> None:
+    """STAGE_ROLE_MAP must map specialist stages to correct roles."""
+    assert STAGE_ROLE_MAP.get(stage) == expected_role
+
+
+@pytest.mark.parametrize("stage,expected_role", SPECIALIST_STAGE_ROLE_PAIRS)
+def test_role_for_stage_specialists(stage: str, expected_role: str) -> None:
+    """role_for_stage() must resolve specialist stages without workflow."""
+    assert role_for_stage(stage) == expected_role
+
+
+# ── 5. Integration: brief→stages→roles end-to-end ──────────────────────
+
+def test_end_to_end_brief_to_roles(tmp_path: Path) -> None:
+    """Full path: brief domains → specialists_from_brief → role_for_stage for each."""
+    brief = {"required_specialists": ["security", "frontend", "perf"]}
+    (tmp_path / "brief.json").write_text(json.dumps(brief), encoding="utf-8")
+
+    stages = specialists_from_brief(tmp_path)
+    # Must resolve to at least the stage names
+    assert len(stages) >= 3, f"Expected >=3 specialists, got {stages}"
+
+    for stage in stages:
+        role = role_for_stage(stage)
+        assert role in SPECIALIST_ROLES, (
+            f"Stage {stage} resolved to unknown role: {role}"
+        )


### PR DESCRIPTION
## Summary

Issue #135 — spec-based specialist 에이전트 6종을 런타임 실행 경로에 연결.

## Changes

- `DOMAIN_TO_STAGE` 매핑 6개 추가 (security→security-review 등)
- `ROLE_TO_FILENAME` 11개로 확장 (generator.py + preset_resolver.py 양쪽)
- `specialists_from_brief()` 도메인명/스테이지명 둘 다 처리
- Codex `plugin.json` specialist 6종 supports_roles/agents 추가
- `operator_routing.py`에 `_normalise_specialist()` 추가
- specialist 프롬프트 6개 `prompts/canonical/`에 추가
- route 용어 정리: "high risk" → "high" (docs)

## Tests

- 48개 TDD 테스트 추가 (`test_specialist_wiring.py`)
- 전체 1541 passed, 0 failed

fixes #135