### PR TITLE
docs: document evaluation workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,13 @@ memory/                  # Version-controlled local memory: curated patterns, de
 - Use `tmp_path` or `tests/runtime/conftest.py` fixtures for task directories.
 - Aim for meaningful coverage — test the contract, not just imports.
 - Run full suite before committing: `python3 -m pytest -q`
+- For route/stage/gate/artifact/review policy changes, run `make evals` or the narrow `make adherence-evals` target and include the result in the PR/handoff.
+
+## PR Checklist
+
+- Tests or evals were run for the changed contract surface.
+- `make evals` evidence is included when workflow policy, fixtures, gates, stages, routes, review reports, or artifact schemas change.
+- Documentation under `docs/` or `evals/` is updated when eval semantics or suite coverage change.
 
 ## Do NOT
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,21 @@ Windows PowerShell:
 - **2-axis specialist selection** — route 축(작업 크기)과 spec 축(전문 에이전트)이 독립 작동합니다. security/backend/frontend/infra/ux/perf 6개 도메인 → [docs/workflow.md](docs/workflow.md)
 - **Adapter boundary** — Claude Code, Codex, Gemini CLI에서 동일한 workflow를 보장하는 adapter 계층 → [docs/adapter-model.md](docs/adapter-model.md)
 
+## Evaluation
+
+ForgeFlow evals는 workflow 계약이 실제 executable check로 유지되는지 검증합니다. Unit test가 코드 동작을 보는 쪽이라면, eval은 stage/gate/artifact/review 정책이 우회되지 않는지 보는 쪽입니다.
+
+```bash
+make setup
+make check-env
+make evals
+```
+
+- 전체 eval 실행: `make evals`
+- adherence suite만 실행: `make adherence-evals`
+- 결과 해석과 suite 추가 절차: [docs/evaluation-guide.md](docs/evaluation-guide.md)
+- suite별 fixture 설명: [evals/README.md](evals/README.md)
+
 ## 문제 해결
 
 자주 묻는 질문과 해결 방법:

--- a/docs/evaluation-guide.md
+++ b/docs/evaluation-guide.md
@@ -1,0 +1,62 @@
+# Evaluation guide
+
+ForgeFlow evals are executable workflow checks. They are not prose guidelines, and they are not a replacement for unit tests. Unit tests verify code behavior; evals verify that the harness still enforces its artifact, stage, route, and review contracts end to end.
+
+## Quick start
+
+From a fresh clone, prepare the repo-managed virtualenv first:
+
+```bash
+make setup
+make check-env
+make evals
+```
+
+For only the workflow adherence suite:
+
+```bash
+make adherence-evals
+```
+
+Both targets use `.venv` through the Makefile. A failing eval exits non-zero, so CI can trust the command status directly.
+
+## Current suites
+
+- `adherence` — validates route/stage/gate behavior against positive and negative fixtures. It catches policy bypasses such as missing required artifacts, stale task IDs, out-of-sequence checkpoints, invalid review reports, and long-run gates without eval evidence.
+
+Suite details live in:
+
+- `evals/README.md`
+- `evals/adherence/README.md`
+- `scripts/run_evals.py`
+- `scripts/run_adherence_evals.py`
+
+## Reading results
+
+`make evals` prints suite-level status:
+
+- `FORGEFLOW EVALS: PASS` — every registered suite passed.
+- `FORGEFLOW EVALS: FAIL` — at least one registered suite failed.
+- `EVAL SUITE: <name> PASS` — one suite passed.
+- `EVAL SUITE: <name> FAIL exit_code=<n>` — one suite failed and returned a non-zero exit code.
+
+The adherence runner also prints individual fixture outcomes. Positive fixtures should run to the expected terminal stage. Negative fixtures should be blocked with the expected `RuntimeViolation`. If a negative fixture starts passing, that is usually bad: the harness just lost a guardrail.
+
+## Adding or changing a suite
+
+1. Add or update fixtures under `evals/<suite>/` or the relevant runtime fixture directory.
+2. Document the fixture intent in the suite README.
+3. Add the runner command to `scripts/run_evals.py`.
+4. Add a Makefile target if developers need to run the suite directly.
+5. Add or update tests that lock the runner contract.
+6. Run `make evals` and the narrow tests touched by the suite.
+
+Do not add a docs-only eval. If it cannot fail automatically, it is not an eval; it is a wish with Markdown syntax highlighting.
+
+## PR checklist
+
+For changes touching routes, stages, artifact schemas, review gates, policy, or examples:
+
+- Run `make evals` or explain why it is not relevant.
+- Include the eval command and result in the PR body or handoff.
+- Update `evals/README.md` and this guide when adding a new suite or changing output semantics.


### PR DESCRIPTION
Closes #134

## Summary
- add top-level README Evaluation section with eval commands
- add docs/evaluation-guide.md with usage, result interpretation, and suite extension rules
- add AGENTS.md PR checklist guidance for eval evidence

## Verification
- make evals: PASS
- python3 scripts/validate_structure.py: PASS