### PR TITLE
경로 검증과 스모크 안정성 강화

### DIFF
--- a/scripts/bootstrap_codex_plugin.py
+++ b/scripts/bootstrap_codex_plugin.py
@@ -104,11 +104,13 @@ def verify_checksum(archive_path: Path, expected_hex: str) -> None:
 def safe_extract(zf: zipfile.ZipFile, dest: Path) -> None:
     """Extract with zip bomb protection and path traversal guard."""
     total = 0
+    dest_resolved = dest.resolve()
     for info in zf.infolist():
-        # Path traversal guard
         target = (dest / info.filename).resolve()
-        if not str(target).startswith(str(dest.resolve())):
-            raise ValueError(f"Path traversal detected: {info.filename}")
+        try:
+            target.relative_to(dest_resolved)
+        except ValueError as exc:
+            raise ValueError(f"Path traversal detected: {info.filename}") from exc
 
         if info.file_size > MAX_SINGLE_FILE_BYTES:
             raise ValueError(

--- a/scripts/ci_plugin_smoke_matrix.py
+++ b/scripts/ci_plugin_smoke_matrix.py
@@ -26,6 +26,15 @@ ROUTE_REQUESTS = {
     "epic": "redesign a multi-service production platform across auth, billing, database migrations, deployment rollback, observability, security review, phased rollout, and post-release monitoring",
 }
 SKIP_DIRS = {".git", ".omx", "node_modules", ".next"}
+DISPOSABLE_NEXTJS_DEPENDENCIES = {
+    "next": "14.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+}
+DISPOSABLE_NEXTJS_DEV_DEPENDENCIES = {
+    "typescript": "5.3.0",
+    "eslint": "8.57.0",
+}
 
 
 def run(command: list[str], cwd: Path, timeout: int = 180, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -68,8 +77,8 @@ def create_disposable_nextjs_project(base: Path) -> Path:
         json.dumps(
             {
                 "scripts": {"lint": "next lint", "build": "next build", "dev": "next dev"},
-                "dependencies": {"next": "latest", "react": "latest", "react-dom": "latest"},
-                "devDependencies": {"typescript": "latest", "eslint": "latest"},
+                "dependencies": DISPOSABLE_NEXTJS_DEPENDENCIES,
+                "devDependencies": DISPOSABLE_NEXTJS_DEV_DEPENDENCIES,
             },
             indent=2,
         )

--- a/scripts/validate_context_paths.py
+++ b/scripts/validate_context_paths.py
@@ -99,8 +99,14 @@ def is_example_reference(reference: str) -> bool:
 
 def reference_exists(root: Path, context_file: Path, reference: str) -> bool:
     if reference.startswith("/"):
-        # Absolute sample paths are not repo-local evidence.
-        return is_example_reference(reference)
+        if is_example_reference(reference):
+            return True
+        absolute_reference = Path(reference).resolve()
+        try:
+            absolute_reference.relative_to(root.resolve())
+        except ValueError:
+            return False
+        return absolute_reference.exists()
 
     normalized = reference.removeprefix("./")
     candidates = [root / normalized, context_file.parent / reference]

--- a/tests/runtime/test_package_install.py
+++ b/tests/runtime/test_package_install.py
@@ -3,6 +3,8 @@ import sys
 import tomllib
 from pathlib import Path
 
+import pytest
+
 from tests.runtime.cli_helpers import ROOT
 
 
@@ -34,7 +36,17 @@ def test_console_script_target_can_run_orchestrator_help() -> None:
 
 def test_editable_install_exposes_forgeflow_entrypoint(tmp_path: Path) -> None:
     venv_dir = tmp_path / "venv"
-    subprocess.run([sys.executable, "-m", "venv", str(venv_dir)], check=True)
+    venv_result = subprocess.run(
+        [sys.executable, "-m", "venv", str(venv_dir)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if venv_result.returncode != 0:
+        details = "\n".join(part for part in [venv_result.stdout.strip(), venv_result.stderr.strip()] if part).casefold()
+        if any(marker in details for marker in ["ensurepip", "python3-venv", "no module named venv"]):
+            pytest.skip("stdlib venv unavailable in this environment")
+        raise AssertionError(venv_result.stderr or venv_result.stdout)
     python = venv_dir / "bin" / "python"
     forgeflow = venv_dir / "bin" / "forgeflow"
 

--- a/tests/test_bootstrap_security.py
+++ b/tests/test_bootstrap_security.py
@@ -89,6 +89,21 @@ def test_safe_extract_rejects_path_traversal(tmp_path: Path):
     zf.close()
 
 
+def test_safe_extract_rejects_sibling_prefix_traversal(tmp_path: Path):
+    from scripts.bootstrap_codex_plugin import safe_extract
+
+    zip_data = _make_zip({"../out-evil/payload.txt": "surprise\n"})
+    buf = io.BytesIO(zip_data)
+    zf = zipfile.ZipFile(buf)
+
+    dest = tmp_path / "out"
+    dest.mkdir()
+
+    with pytest.raises(ValueError, match="[Pp]ath traversal"):
+        safe_extract(zf, dest)
+    zf.close()
+
+
 def test_safe_extract_rejects_oversized_single_file(tmp_path: Path):
     from scripts.bootstrap_codex_plugin import safe_extract, MAX_SINGLE_FILE_BYTES
 

--- a/tests/test_plugin_smoke_ci_contract.py
+++ b/tests/test_plugin_smoke_ci_contract.py
@@ -80,6 +80,20 @@ def test_readme_documents_local_disposable_nextjs_plugin_smoke() -> None:
         assert required in readme
 
 
+def test_ci_plugin_smoke_script_pins_disposable_nextjs_dependency_versions() -> None:
+    smoke = SMOKE.read_text(encoding="utf-8")
+    assert '"next": "latest"' not in smoke
+    assert '"react": "latest"' not in smoke
+    assert '"react-dom": "latest"' not in smoke
+    assert '"typescript": "latest"' not in smoke
+    assert '"eslint": "latest"' not in smoke
+    assert '"next": "14.0.0"' in smoke
+    assert '"react": "18.2.0"' in smoke
+    assert '"react-dom": "18.2.0"' in smoke
+    assert '"typescript": "5.3.0"' in smoke
+    assert '"eslint": "8.57.0"' in smoke
+
+
 def test_claude_code_install_docs_keep_plugin_commands_but_mark_unsupported() -> None:
     for path in [README, ROOT / "INSTALL.md"]:
         text = path.read_text(encoding="utf-8")

--- a/tests/test_validate_context_paths.py
+++ b/tests/test_validate_context_paths.py
@@ -77,6 +77,32 @@ def test_context_path_validator_accepts_existing_hidden_dir_refs(tmp_path: Path)
     assert validator.find_broken_references(tmp_path) == []
 
 
+def test_context_path_validator_reports_missing_repo_internal_absolute_refs(tmp_path: Path) -> None:
+    validator = _load_validator_module()
+    missing = tmp_path / "docs" / "missing-guide.md"
+    (tmp_path / "README.md").write_text(
+        f"Use `{missing.resolve().as_posix()}` for local setup.\n",
+        encoding="utf-8",
+    )
+
+    broken = validator.find_broken_references(tmp_path)
+
+    assert [item.render() for item in broken] == [f"README.md:1: {missing.resolve().as_posix()}"]
+
+
+def test_context_path_validator_accepts_existing_repo_internal_absolute_refs(tmp_path: Path) -> None:
+    validator = _load_validator_module()
+    guide = tmp_path / "docs" / "guide.md"
+    guide.parent.mkdir(parents=True)
+    guide.write_text("# Guide\n", encoding="utf-8")
+    (tmp_path / "README.md").write_text(
+        f"Use `{guide.resolve().as_posix()}` for local setup.\n",
+        encoding="utf-8",
+    )
+
+    assert validator.find_broken_references(tmp_path) == []
+
+
 def test_context_path_validator_ignores_generated_and_upstream_context(tmp_path: Path) -> None:
     validator = _load_validator_module()
     generated = tmp_path / "adapters" / "generated" / "claude"


### PR DESCRIPTION
## Summary
- zip 추출 경로 검사를 `relative_to()` 기반으로 강화하고 sibling-prefix traversal 회귀 테스트를 추가했습니다.
- context path validator가 repo 내부 절대 경로를 실제 존재 여부로 판정하도록 보정했습니다.
- disposable Next.js smoke app 의존성을 exact version으로 고정하고, `venv` 미지원 환경에서는 패키지 설치 테스트가 명확히 skip되도록 정리했습니다.

## Test plan
- [x] python3 scripts/check_plugin_versions.py
- [x] python3 scripts/validate_context_paths.py
- [x] python3 scripts/validate_structure.py
- [x] python3 scripts/validate_policy.py
- [x] python3 scripts/validate_generated.py
- [x] python3 scripts/validate_sample_artifacts.py
- [x] python3 scripts/validate_upstream_import.py
- [x] python3 scripts/validate_hoyeon_import.py
- [x] python3 scripts/validate_skill_contracts.py
- [x] python3 scripts/validate_claude_hooks.py
- [x] python3 scripts/validate_contract_map.py
- [x] python3 scripts/validate_vocabulary_drift.py
- [x] python3 scripts/run_adherence_evals.py
- [x] python3 scripts/smoke_plan_cli.py
- [x] python3 -m pytest tests/evolution -q
- [x] python3 -m pytest tests/runtime -q
- [x] python3 -m pytest tests/test_forgeflow_ux_contract.py -q
- [x] python3 -m pytest tests/test_forgeflow_learn.py -q
- [x] python3 -m pytest tests/test_claude_recovery_hooks.py -q
- [x] python3 -m pytest tests/test_shared_recovery_contract.py -q
- [x] python3 -m pytest tests/test_team_pattern_contract.py -q
- [x] python3 -m pytest tests/test_agent_preset_install.py -q
- [x] python3 -m pytest tests/test_claude_agent_preset_install.py -q
- [x] python3 -m pytest tests/test_codex_plugin_install.py -q
- [x] python3 -m pytest tests/test_first_clone_setup.py -q
- [x] python3 -m pytest tests/test_release_script.py -q
- [x] python3 -m pytest tests/test_finish_skill_contract.py -q
- [x] python3 -m pytest tests/test_plugin_manifests.py -q
- [x] python3 scripts/ci_plugin_smoke_matrix.py --surface claude --route-label small --static-only
- [x] python3 scripts/ci_plugin_smoke_matrix.py --surface codex --route-label medium --static-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)