### PR TITLE
docs: tighten loop artifact contracts

### DIFF
--- a/skills/_shared/context-resume.md
+++ b/skills/_shared/context-resume.md
@@ -24,7 +24,7 @@ Do **not** refresh context when:
 
 - A file edit is in progress and not saved to artifact or codebase.
 - Verification ran but results are not yet in `implementation-notes.md` Evidence.
-- A subagent/worker is `running` in `ledger.md` without evidence refs.
+- A subagent/worker is `in_progress` in `ledger.md` without evidence refs.
 - You are mid-review before verdict is recorded.
 
 | Stage | Safe to refresh after | Unsafe during |

--- a/skills/execute/SKILL.md
+++ b/skills/execute/SKILL.md
@@ -217,7 +217,7 @@ Minimum warning contract:
      - After each task completes, append compact evidence index line to `implementation-notes.md` Evidence (e.g. `evidence_index: task=T3 gates=build:PASS,lint:PASS`).
    - **Implementation Notes**: When a decision is made that was not in the plan, when the implementation deviates from the spec, when a tradeoff is chosen, or when an open question arises — **append an entry to `implementation-notes.md` immediately**. Do not batch these until the end.
    - **TDD Refactor**: Clean up implementation.
-   - **Run Ledger**: When starting a task, set its status to `running` and **Assignee** to `worker` (or `specialist` if delegated). When completing, set to `done` with evidence refs. When blocked, set to `blocked` with blocker description. Update incrementally, not in batch. See **Run ledger assignee discipline** below.
+   - **Run Ledger**: When starting a task, set its status to `in_progress` and **Assignee** to `worker` (or `specialist` if delegated). When completing, set to `done` with evidence refs. When blocked, set to `blocked` with blocker description. Update incrementally, not in batch. See **Run ledger assignee discipline** below.
    - **Per-task micro-gates (high/epic only)**: Before marking a step `done`, run the micro-gate checklist in **Per-task micro-gates** below. Optional spec/quality micro-reviewer subagents use `references/spec-reviewer-prompt.md` and `references/quality-reviewer-prompt.md`.
    - **Checkpoint**: Update `checkpoint.md` after each task completes: set `Active Task` to the next task, update `Latest Artifacts` table. Ensures resume capability after adapter-selected context refresh.
      - **Step-boundary checkpoint (adapter-neutral)**: Once checkpoint, ledger, and evidence are all updated on disk for a completed step, set `checkpoint.md` `Active Task` to the real next task id and `Next Action` to `"Task N 시작; resume from checkpoint if context was refreshed"`. Then either continue immediately (normal `--auto` path) or, if context pressure is high, emit the adapter-specific refresh hint and STOP:
@@ -328,10 +328,10 @@ Micro-gates run **during execute** on **high** and **epic** routes. They do not 
 
 | Event | Status | Assignee |
 |-------|--------|----------|
-| Step started (controller) | `running` | `worker` |
-| Specialist subagent dispatched | `running` | `specialist` |
-| Spec micro-review pass | `running` | `spec-reviewer` |
-| Quality micro-review pass | `running` | `quality-reviewer` |
+| Step started (controller) | `in_progress` | `worker` |
+| Specialist subagent dispatched | `in_progress` | `specialist` |
+| Spec micro-review pass | `in_progress` | `spec-reviewer` |
+| Quality micro-review pass | `in_progress` | `quality-reviewer` |
 | Step verified complete | `done` | last active role (`worker` or `specialist`) |
 | Blocked | `blocked` | role that hit the blocker |
 

--- a/skills/execute/references/quality-reviewer-prompt.md
+++ b/skills/execute/references/quality-reviewer-prompt.md
@@ -72,7 +72,7 @@ Task tool:
 
 Verdict → controller mapping:
 - **approved** → `micro_quality:PASS step=<name>`, safe to mark step `done`
-- **changes_requested** → `micro_quality:FAIL step=<name>`, keep step `running`
+- **changes_requested** → `micro_quality:FAIL step=<name>`, keep step `in_progress`
 - **blocked** → `micro_quality:FAIL step=<name>`, move step to `blocked`
 
 Controller actions after micro-review:

--- a/skills/execute/references/spec-reviewer-prompt.md
+++ b/skills/execute/references/spec-reviewer-prompt.md
@@ -67,7 +67,7 @@ Task tool:
 
 Verdict → controller mapping:
 - **approved** → `micro_spec:PASS step=<name>`, proceed to quality micro-review
-- **changes_requested** → `micro_spec:FAIL step=<name>`, keep step `running`
+- **changes_requested** → `micro_spec:FAIL step=<name>`, keep step `in_progress`
 - **blocked** → `micro_spec:FAIL step=<name>`, move step to `blocked`
 
 Controller actions after micro-review:

--- a/skills/execute/references/subagent-loop.md
+++ b/skills/execute/references/subagent-loop.md
@@ -25,7 +25,7 @@ Do **not** use for small route (overhead exceeds benefit).
 For each plan step in dependency order:
 
 ```text
-1. Controller sets ledger: running, Assignee worker, Claim Marker with role/scope/timestamp
+1. Controller sets ledger: in_progress, Assignee worker, Claim Marker with role/scope/timestamp
    → Record dispatch: "implementer-prompt.md"
 2. Dispatch implementer subagent (references/implementer-prompt.md)
 3. If NEEDS_CONTEXT → provide context and re-dispatch

--- a/templates/checkpoint.md
+++ b/templates/checkpoint.md
@@ -1,5 +1,7 @@
 # Checkpoint
 
+<!-- Resume source of truth. On context compression or handoff, read this file first, then the ledger row named in Resume Pointer, then implementation-notes.md Reader Summary/Evidence Index. -->
+
 ## Current Stage
 <!-- clarify | plan | execute | review | ship | long-run -->
 
@@ -9,8 +11,17 @@
 ## Active Task
 <!-- Which task from plan.md / ledger.md is currently in progress, or "none" -->
 
+## Resume Pointer
+<!-- Required before every handoff/compression: ledger task heading/id, current status, retry count, owner, and exact artifact section to update next. Example: ledger.md#task-2-update-docs status=in_progress retry=1 owner=worker next_update=implementation-notes.md#Evidence -->
+
 ## Next Action
 <!-- The single action to take when resuming -->
+
+## Last Verified Evidence
+<!-- Most recent real command/artifact evidence. Use "none" if no command has run yet. Example: evidence_index:task=T2 command="make validate" exit=0 artifact=implementation-notes.md#Evidence -->
+
+## Resume Read Order
+<!-- Default: checkpoint.md Resume Pointer → ledger.md matching task row → implementation-notes.md Reader Summary → implementation-notes.md Evidence Index → plan.md referenced item only. Do not reload the whole chat transcript as state. -->
 
 ## Blockers
 <!-- List active blockers or "none" -->

--- a/templates/implementation-notes.md
+++ b/templates/implementation-notes.md
@@ -53,10 +53,40 @@
 <!-- Use compact strings parseable by review/ship preflight: verification:PASS/FAIL, contract_check:PASS/FAIL, evidence_index:task=... -->
 -
 
+### Command Evidence Format
+
+<!-- Append one block per real command. Do not summarize invented or unrun commands. -->
+
+```text
+evidence_id: E-<!-- N -->
+task: <!-- ledger task id/title -->
+kind: command
+cwd: <!-- absolute or repo-relative cwd -->
+command: <!-- exact command -->
+exit_code: <!-- integer -->
+result: <!-- PASS | FAIL | SKIPPED -->
+output_summary: <!-- short factual summary; include counts/errors, not vibes -->
+artifact_ref: <!-- path, log file, PR/check URL, or "inline" -->
+timestamp: <!-- ISO8601 -->
+```
+
+### Artifact Evidence Format
+
+```text
+evidence_id: E-<!-- N -->
+task: <!-- ledger task id/title -->
+kind: artifact
+path: <!-- file path or URL -->
+claim_verified: <!-- what this artifact proves -->
+result: <!-- PASS | FAIL | SKIPPED -->
+timestamp: <!-- ISO8601 -->
+```
+
 ## Evidence Index
 <!-- Compact refs updated during execute. Parse before expanding full Evidence above. -->
 <!-- Example: evidence_index: task=T2 gates=make validate:PASS,contract_check:PASS -->
 <!-- ledger.md = per-task status truth; this file = decisions + evidence narrative -->
+- `evidence_index: task=<ledger-task> evidence=<E-N> command="<cmd>" exit=<code> result=<PASS|FAIL|SKIPPED> artifact=<path|inline>`
 
 ## 컴포넌트/함수 역할 (Role Descriptions)
 <!-- One-line role for each changed component/function. Required for all routes. -->

--- a/templates/ledger.md
+++ b/templates/ledger.md
@@ -10,6 +10,19 @@ total_items: <!-- N -->
 <!-- ForgeFlow unified tracking. Plan stage writes Plan Items; Execute stage updates Execution Tracking. -->
 <!-- Replaces plan-ledger.md and run-ledger.md (both deprecated as of v1.11). -->
 <!-- Status truth lives here; implementation-notes.md holds decision narrative — read ledger first on resume. -->
+<!-- Loop item status enum: pending | in_progress | blocked | done | discarded. Do not invent alternate status words. -->
+<!-- Resume rule: checkpoint.md points to exactly one ledger task; ledger owns item status, retry count, blocker, and evidence refs. -->
+
+## Loop Status Contract
+
+- **Allowed Status Values**: `pending`, `in_progress`, `blocked`, `done`, `discarded`
+- **pending**: item is queued and has not been claimed.
+- **in_progress**: item is currently claimed by the assignee named in `Claim Marker`.
+- **blocked**: item cannot proceed without a recorded blocker or user decision.
+- **done**: item has verification evidence and needs no more execute work.
+- **discarded**: item was deliberately removed from the loop scope; record the decision in `## Decisions`.
+- **Resume Pointer Rule**: `checkpoint.md` `## Resume Pointer` must name the next ledger task before context compression or handoff.
+- **Evidence Rule**: every `done` item must cite at least one `Evidence Refs` entry from `implementation-notes.md` `## Evidence Index` or a concrete artifact path.
 
 ## Plan Items
 
@@ -23,7 +36,7 @@ total_items: <!-- N -->
 
 ### Task 1: <!-- name -->
 - **Plan Step**: <!-- which plan step or brief objective -->
-- **Status**: <!-- pending | running | done | blocked | skipped -->
+- **Status**: <!-- pending | in_progress | blocked | done | discarded -->
 - **Assignee**: <!-- worker | specialist | spec-reviewer | quality-reviewer -->
 - **Claim Marker**: <!-- role=<worker|specialist|spec-reviewer|quality-reviewer> scope=<repo paths or artifact section> at=<ISO8601>; none for direct sequential worker -->
 - **Evidence Refs**: <!-- compact strings: verification:PASS gate=... | contract_check:PASS | evidence_index:task=... -->
@@ -61,7 +74,7 @@ total_items: <!-- N -->
 - **Total Tasks**: 0
 - **Completed**: 0
 - **Blocked**: 0
-- **Skipped**: 0
+- **Discarded**: 0
 - **All Done**: <!-- yes | no -->
 
 ## Small Route Minimal Format
@@ -113,6 +126,6 @@ worker = direct implementation (small route는 specialist 사용 안 함)
 - **Total Tasks**: 1
 - **Completed**: 0
 - **Blocked**: 0
-- **Skipped**: 0
+- **Discarded**: 0
 - **All Done**: no
 ```


### PR DESCRIPTION
## Summary
- Tightens `ledger.md` into a loop-friendly status contract with canonical item states: `pending`, `in_progress`, `blocked`, `done`, `discarded`.
- Adds checkpoint resume pointer/read-order/evidence fields so context-compressed runs can restart from artifacts instead of chat memory.
- Adds fixed command/artifact evidence formats to `implementation-notes.md`.
- Updates execute/context docs from `running` to canonical `in_progress`.

## Verification
- `make validate` ✅

Closes #162
