### PR TITLE
Add ForgeFlow loop adapter execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,17 @@ make validate
 
 `make validate`는 문서/JSON/skill/template/link/route/release/adapter/eval 계약을 검사합니다. live provider/plugin E2E를 실행하지 않습니다. Markdown link 검증은 HTML href/src 링크도 포함합니다. 큰 workflow skill은 `docs/skill-modularization.md` 정책에 따라 shared/reference로 쪼개졌는지도 검사합니다.
 
+Local loop CLI는 `scripts/forgeflow_loop.py`입니다. 현재 지원 명령은 `status`, `next`, `record`, `run-adapter`입니다. `run-adapter`는 task artifact를 `agent-prompt.md`로 묶어 adapter command의 stdin에 넣고, adapter stdout/stderr와 verification command 결과를 `implementation-notes.md` 및 `ledger.md`에 남깁니다. 검증 실패는 성공으로 포장하지 않고 item을 `blocked`로 기록합니다.
+
+```bash
+python3 scripts/forgeflow_loop.py status --task-dir <task-dir>
+python3 scripts/forgeflow_loop.py next --task-dir <task-dir>
+python3 scripts/forgeflow_loop.py record --task-dir <task-dir> --status done --evidence "command=make-validate exit=0"
+python3 scripts/forgeflow_loop.py run-adapter --task-dir <task-dir> --adapter stub --command "python3 -c 'import sys; print(sys.stdin.read())'" --verify-command "python3 -c 'print(\"verified\")'"
+```
+
+실제 Claude/Codex/Gemini CLI에 붙일 때도 원칙은 같습니다. command template은 `{task_dir}`와 `{prompt}`를 쓸 수 있고, prompt는 stdin으로도 들어갑니다. 예: `--command "claude -p @{prompt}"`, `--command "codex exec --full-auto -"`, `--command "gemini -p @{prompt}"`. 단, 검증 증거는 adapter 자기보고가 아니라 `--verify-command`의 실제 출력이어야 합니다.
+
 자주 쓰는 focused target:
 
 ```bash

--- a/scripts/forgeflow_loop.py
+++ b/scripts/forgeflow_loop.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import argparse
 import datetime as _dt
 import re
+import shlex
+import subprocess
 import sys
 from pathlib import Path
 
@@ -30,6 +32,16 @@ def read_text(path: Path) -> str:
 
 def task_paths(task_dir: Path) -> tuple[Path, Path]:
     return task_dir / "ledger.md", task_dir / "checkpoint.md"
+
+
+def artifact_paths(task_dir: Path) -> dict[str, Path]:
+    return {
+        "brief": task_dir / "brief.md",
+        "plan": task_dir / "plan.md",
+        "ledger": task_dir / "ledger.md",
+        "checkpoint": task_dir / "checkpoint.md",
+        "implementation_notes": task_dir / "implementation-notes.md",
+    }
 
 
 def parse_tasks(ledger_text: str) -> list[dict[str, str]]:
@@ -202,6 +214,97 @@ def record(task_dir: Path, status: str, evidence: str, task_name: str | None, bl
     return 0
 
 
+def build_adapter_prompt(task_dir: Path, task: dict[str, str]) -> str:
+    paths = artifact_paths(task_dir)
+    sections = [
+        "You are an agent adapter running one ForgeFlow task.",
+        "Do the task, but do not claim success without verifiable evidence.",
+        f"Active task: {format_task(task)}",
+    ]
+    for name in ("brief", "plan", "ledger", "checkpoint"):
+        path = paths[name]
+        if path.exists():
+            sections.append(f"\n--- {path.name} ---\n{read_text(path)}")
+    return "\n".join(sections).strip() + "\n"
+
+
+def render_command(command_template: str, task_dir: Path, prompt_path: Path) -> list[str]:
+    rendered = command_template.format(task_dir=str(task_dir), prompt=str(prompt_path))
+    return shlex.split(rendered)
+
+
+def append_agent_run(
+    task_dir: Path,
+    task: dict[str, str],
+    adapter: str,
+    prompt_path: Path,
+    proc: subprocess.CompletedProcess[str],
+    verify: subprocess.CompletedProcess[str] | None,
+) -> None:
+    now = _dt.datetime.now(_dt.timezone.utc).replace(microsecond=0).isoformat()
+    notes_path = artifact_paths(task_dir)["implementation_notes"]
+    notes_path.touch(exist_ok=True)
+    verification = "not_run" if verify is None else f"exit={verify.returncode}\nstdout:\n{verify.stdout.strip()}\nstderr:\n{verify.stderr.strip()}"
+    block = (
+        f"\n\n## Agent Adapter Run - {now}\n"
+        f"- task: {task['heading']}\n"
+        f"- adapter: {adapter}\n"
+        f"- prompt: {prompt_path.name}\n"
+        f"- adapter_exit: {proc.returncode}\n"
+        f"- verification: {verification}\n\n"
+        f"### Adapter stdout\n```text\n{proc.stdout.strip()}\n```\n\n"
+        f"### Adapter stderr\n```text\n{proc.stderr.strip()}\n```\n"
+    )
+    notes_path.write_text(notes_path.read_text(encoding="utf-8") + block, encoding="utf-8")
+
+    ledger_path = artifact_paths(task_dir)["ledger"]
+    verify_label = "not_run" if verify is None else str(verify.returncode)
+    ledger_path.write_text(
+        read_text(ledger_path)
+        + f"\n## Agent Runs\n- {now} task={task['heading']} adapter={adapter} adapter_exit={proc.returncode} verification={verify_label} notes=implementation-notes.md\n",
+        encoding="utf-8",
+    )
+
+
+def run_adapter(task_dir: Path, adapter: str, command_template: str, verify_command: str | None) -> int:
+    _ledger_path, _checkpoint_path, tasks, checkpoint = load_state(task_dir)
+    task = first_actionable(tasks, checkpoint)
+    if task is None:
+        raise LoopError("no actionable task for adapter run")
+    prompt_path = task_dir / "agent-prompt.md"
+    prompt_path.write_text(build_adapter_prompt(task_dir, task), encoding="utf-8")
+
+    proc = subprocess.run(
+        render_command(command_template, task_dir, prompt_path),
+        cwd=task_dir,
+        text=True,
+        input=prompt_path.read_text(encoding="utf-8"),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    verify = None
+    if verify_command:
+        verify = subprocess.run(
+            render_command(verify_command, task_dir, prompt_path),
+            cwd=task_dir,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+    append_agent_run(task_dir, task, adapter, prompt_path, proc, verify)
+
+    if proc.returncode != 0:
+        return record(task_dir, "blocked", f"adapter={adapter} exit={proc.returncode} notes=implementation-notes.md", task["heading"], "adapter command failed")
+    if verify is not None and verify.returncode != 0:
+        return record(task_dir, "blocked", f"adapter={adapter} verification_exit={verify.returncode} notes=implementation-notes.md", task["heading"], "verification command failed")
+    evidence = f"adapter={adapter} notes=implementation-notes.md"
+    if verify is not None:
+        evidence += f" verification_exit={verify.returncode}"
+    return record(task_dir, "done", evidence, task["heading"], None)
+
+
 def replace_section(text: str, heading: str, body: str) -> str:
     lines = text.splitlines()
     out: list[str] = []
@@ -239,6 +342,11 @@ def main(argv: list[str] | None = None) -> int:
     rec.add_argument("--evidence", default="")
     rec.add_argument("--task", default=None, help="substring of task heading to update")
     rec.add_argument("--blocker", default=None)
+    run = sub.add_parser("run-adapter")
+    run.add_argument("--task-dir", required=True, type=Path)
+    run.add_argument("--adapter", required=True, help="adapter label, for example claude/codex/gemini/stub")
+    run.add_argument("--command", dest="adapter_command", required=True, help="adapter command template; receives prompt on stdin; supports {task_dir} and {prompt}")
+    run.add_argument("--verify-command", default=None, help="verification command template; supports {task_dir} and {prompt}")
     args = parser.parse_args(argv)
     try:
         task_dir = args.task_dir.expanduser().resolve()
@@ -248,6 +356,8 @@ def main(argv: list[str] | None = None) -> int:
             return print_next(task_dir)
         if args.command == "record":
             return record(task_dir, args.status, args.evidence, args.task, args.blocker)
+        if args.command == "run-adapter":
+            return run_adapter(task_dir, args.adapter, args.adapter_command, args.verify_command)
     except LoopError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2

--- a/scripts/validate_forgeflow_loop.py
+++ b/scripts/validate_forgeflow_loop.py
@@ -96,6 +96,9 @@ def main() -> int:
         task_dir.mkdir(parents=True)
         (task_dir / "ledger.md").write_text(LEDGER, encoding="utf-8")
         (task_dir / "checkpoint.md").write_text(CHECKPOINT, encoding="utf-8")
+        (task_dir / "brief.md").write_text("# Brief\nAdd the smoke marker.\n", encoding="utf-8")
+        (task_dir / "plan.md").write_text("# Plan\nOne small task.\n", encoding="utf-8")
+        (task_dir / "implementation-notes.md").write_text("# Implementation Notes\n", encoding="utf-8")
 
         out = assert_ok(run("next", "--task-dir", str(task_dir), cwd=ROOT))
         assert_contains(out, "Task 2: Add smoke")
@@ -125,6 +128,51 @@ def main() -> int:
         assert_contains(ledger, "evidence_index:task=T2")
         assert_contains(checkpoint, "Task 2: Add smoke status=done")
         assert_contains(checkpoint, "recorded_at=")
+
+        adapter_task_dir = tmp / ".forgeflow" / "tasks" / "adapter"
+        shutil.copytree(task_dir, adapter_task_dir)
+        (adapter_task_dir / "ledger.md").write_text(LEDGER, encoding="utf-8")
+        (adapter_task_dir / "checkpoint.md").write_text(CHECKPOINT, encoding="utf-8")
+        out = assert_ok(
+            run(
+                "run-adapter",
+                "--task-dir",
+                str(adapter_task_dir),
+                "--adapter",
+                "stub",
+                "--command",
+                "python3 -c 'import sys; print(\"adapter saw\", len(sys.stdin.read()))'",
+                "--verify-command",
+                "python3 -c 'from pathlib import Path; print(Path(\"agent-prompt.md\").exists())'",
+                cwd=ROOT,
+            )
+        )
+        assert_contains(out, "recorded: Task 2: Add smoke")
+        assert_contains((adapter_task_dir / "implementation-notes.md").read_text(encoding="utf-8"), "Adapter stdout")
+        assert_contains((adapter_task_dir / "implementation-notes.md").read_text(encoding="utf-8"), "verification: exit=0")
+        assert_contains((adapter_task_dir / "ledger.md").read_text(encoding="utf-8"), "## Agent Runs")
+        assert_contains((adapter_task_dir / "ledger.md").read_text(encoding="utf-8"), "verification_exit=0")
+
+        failed_verify_dir = tmp / ".forgeflow" / "tasks" / "failed-verify"
+        shutil.copytree(task_dir, failed_verify_dir)
+        (failed_verify_dir / "ledger.md").write_text(LEDGER, encoding="utf-8")
+        (failed_verify_dir / "checkpoint.md").write_text(CHECKPOINT, encoding="utf-8")
+        out = assert_ok(
+            run(
+                "run-adapter",
+                "--task-dir",
+                str(failed_verify_dir),
+                "--adapter",
+                "stub",
+                "--command",
+                "python3 -c 'print(\"adapter ok\")'",
+                "--verify-command",
+                "python3 -c 'import sys; print(\"verify failed\"); sys.exit(3)'",
+                cwd=ROOT,
+            )
+        )
+        assert_contains(out, "status=blocked")
+        assert_contains((failed_verify_dir / "ledger.md").read_text(encoding="utf-8"), "verification command failed")
 
         blocked_task_dir = tmp / ".forgeflow" / "tasks" / "blocked"
         shutil.copytree(task_dir, blocked_task_dir)


### PR DESCRIPTION
Closes #165

## Summary
- add `run-adapter` to the local ForgeFlow loop CLI
- package task artifacts into `agent-prompt.md` and feed adapter commands via stdin
- record adapter stdout/stderr plus verification output in implementation notes and ledger
- mark adapter or verification failures as blocked instead of self-reported success
- document the adapter contract in README

## Verification
- `make validate-forgeflow-loop` → OK: forgeflow-loop CLI reads, selects, and records markdown loop state
- `make validate` → OK: local validation passed
