### PR TITLE
Add ForgeFlow worktree fanout loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,13 +194,15 @@ make validate
 
 `make validate`는 문서/JSON/skill/template/link/route/release/adapter/eval 계약을 검사합니다. live provider/plugin E2E를 실행하지 않습니다. Markdown link 검증은 HTML href/src 링크도 포함합니다. 큰 workflow skill은 `docs/skill-modularization.md` 정책에 따라 shared/reference로 쪼개졌는지도 검사합니다.
 
-Local loop CLI는 `scripts/forgeflow_loop.py`입니다. 현재 지원 명령은 `status`, `next`, `record`, `run-adapter`입니다. `run-adapter`는 task artifact를 `agent-prompt.md`로 묶어 adapter command의 stdin에 넣고, adapter stdout/stderr와 verification command 결과를 `implementation-notes.md` 및 `ledger.md`에 남깁니다. 검증 실패는 성공으로 포장하지 않고 item을 `blocked`로 기록합니다.
+Local loop CLI는 `scripts/forgeflow_loop.py`입니다. 현재 지원 명령은 `status`, `next`, `record`, `run-adapter`, `fanout`, `fanin`입니다. `run-adapter`는 task artifact를 `agent-prompt.md`로 묶어 adapter command의 stdin에 넣고, adapter stdout/stderr와 verification command 결과를 `implementation-notes.md` 및 `ledger.md`에 남깁니다. 검증 실패는 성공으로 포장하지 않고 item을 `blocked`로 기록합니다. `fanout`/`fanin`은 ledger의 `Claim Marker`를 path ownership으로 보고 겹치지 않는 작업만 git worktree로 나눈 뒤, worker diff가 자기 소유 path만 건드렸는지 확인하고 merge합니다. 즉 "폰에서 150 PR 합치기" 같은 루프를 흉내 내되, 충돌 격리와 검증 증거 없이는 합치지 않습니다.
 
 ```bash
 python3 scripts/forgeflow_loop.py status --task-dir <task-dir>
 python3 scripts/forgeflow_loop.py next --task-dir <task-dir>
 python3 scripts/forgeflow_loop.py record --task-dir <task-dir> --status done --evidence "command=make-validate exit=0"
 python3 scripts/forgeflow_loop.py run-adapter --task-dir <task-dir> --adapter stub --command "python3 -c 'import sys; print(sys.stdin.read())'" --verify-command "python3 -c 'print(\"verified\")'"
+python3 scripts/forgeflow_loop.py fanout --task-dir <task-dir> --project-root . --worker-root /tmp/forgeflow-workers --max-workers 4
+python3 scripts/forgeflow_loop.py fanin --task-dir <task-dir> --project-root . --worker-root /tmp/forgeflow-workers --verify-command "make validate"
 ```
 
 실제 Claude/Codex/Gemini CLI에 붙일 때도 원칙은 같습니다. command template은 `{task_dir}`와 `{prompt}`를 쓸 수 있고, prompt는 stdin으로도 들어갑니다. 예: `--command "claude -p @{prompt}"`, `--command "codex exec --full-auto -"`, `--command "gemini -p @{prompt}"`. 단, 검증 증거는 adapter 자기보고가 아니라 `--verify-command`의 실제 출력이어야 합니다.

--- a/scripts/forgeflow_loop.py
+++ b/scripts/forgeflow_loop.py
@@ -15,8 +15,10 @@ import sys
 from pathlib import Path
 
 ALLOWED_STATUSES = {"pending", "in_progress", "blocked", "done", "discarded"}
+PROTECTED_PATHS = (".git", ".forgeflow")
 TASK_HEADING_RE = re.compile(r"^###\s+(Task\s+\d+:\s+.+?)\s*$")
 FIELD_RE = re.compile(r"^- \*\*(Status|Assignee|Claim Marker|Evidence Refs|Blocker|Retry Count)\*\*:\s*(.*)$")
+FANOUT_RE = re.compile(r"^- (?P<stamp>\S+) task=(?P<task>.+?) worker=(?P<worker>\S+) branch=(?P<branch>\S+) owner=(?P<owner>\S+) status=(?P<status>\S+)")
 
 
 class LoopError(RuntimeError):
@@ -233,6 +235,53 @@ def render_command(command_template: str, task_dir: Path, prompt_path: Path) -> 
     return shlex.split(rendered)
 
 
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9._-]+", "-", value.lower()).strip("-._")
+    return slug[:80] or "worker"
+
+
+def path_owner(task: dict[str, str]) -> str:
+    owner = (task.get("claim_marker") or "").strip()
+    if not owner or owner == "none":
+        owner = slugify(task["heading"])
+    owner = owner.strip("/")
+    if not owner or owner.startswith(PROTECTED_PATHS) or "/.git" in owner or "/.forgeflow" in owner:
+        raise LoopError(f"protected path ownership is not allowed: {owner or 'empty'}")
+    return owner
+
+
+def paths_conflict(left: str, right: str) -> bool:
+    left = left.rstrip("/")
+    right = right.rstrip("/")
+    return left == right or left.startswith(right + "/") or right.startswith(left + "/")
+
+
+def fanout_candidates(tasks: list[dict[str, str]], max_workers: int) -> list[tuple[dict[str, str], str]]:
+    selected: list[tuple[dict[str, str], str]] = []
+    for task in tasks:
+        if task.get("status", "pending") not in {"pending", "in_progress"}:
+            continue
+        owner = path_owner(task)
+        for other_task, other_owner in selected:
+            if paths_conflict(owner, other_owner):
+                raise LoopError(f"conflicting path ownership: {task['heading']}={owner} overlaps {other_task['heading']}={other_owner}")
+        selected.append((task, owner))
+        if len(selected) >= max_workers:
+            break
+    return selected
+
+
+def git(project_root: Path, *args: str, input_text: str | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(project_root), *args],
+        input=input_text,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
 def append_agent_run(
     task_dir: Path,
     task: dict[str, str],
@@ -305,6 +354,102 @@ def run_adapter(task_dir: Path, adapter: str, command_template: str, verify_comm
     return record(task_dir, "done", evidence, task["heading"], None)
 
 
+def worktree_fanout(task_dir: Path, project_root: Path, worker_root: Path, max_workers: int) -> int:
+    ledger_path, _checkpoint_path, tasks, _checkpoint = load_state(task_dir)
+    candidates = fanout_candidates(tasks, max_workers)
+    if not candidates:
+        raise LoopError("no pending or in-progress tasks available for fanout")
+    worker_root.mkdir(parents=True, exist_ok=True)
+    now = _dt.datetime.now(_dt.timezone.utc).replace(microsecond=0).isoformat()
+    lines = ["\n## Worktree Fanout"]
+    created = 0
+    for task, owner in candidates:
+        slug = slugify(task["heading"])
+        worker_path = worker_root / slug
+        branch = f"forgeflow/{slug}"
+        if worker_path.exists():
+            raise LoopError(f"worker path already exists: {worker_path}")
+        proc = git(project_root, "worktree", "add", "-b", branch, str(worker_path), "HEAD")
+        if proc.returncode != 0:
+            raise LoopError(f"git worktree add failed for {task['heading']}: {proc.stderr.strip()}")
+        created += 1
+        lines.append(f"- {now} task={slug} worker={worker_path} branch={branch} owner={owner} status=created")
+    ledger_path.write_text(read_text(ledger_path) + "\n".join(lines) + "\n", encoding="utf-8")
+    print(f"fanout: created={created} worker_root={worker_root}")
+    return 0
+
+
+def parse_fanout_entries(ledger_text: str) -> list[dict[str, str]]:
+    entries: list[dict[str, str]] = []
+    for line in ledger_text.splitlines():
+        match = FANOUT_RE.match(line)
+        if match:
+            entries.append(match.groupdict())
+    return entries
+
+
+def changed_paths(worker: Path) -> list[str]:
+    add_intent = git(worker, "add", "-N", ".")
+    if add_intent.returncode != 0:
+        raise LoopError(f"git add -N failed in {worker}: {add_intent.stderr.strip()}")
+    proc = git(worker, "diff", "--name-only", "HEAD")
+    if proc.returncode != 0:
+        raise LoopError(f"git diff failed in {worker}: {proc.stderr.strip()}")
+    return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+
+
+def validate_worker_changes(entry: dict[str, str], paths: list[str]) -> None:
+    owner = entry["owner"]
+    for path in paths:
+        if path.startswith(PROTECTED_PATHS) or "/.git" in path or "/.forgeflow" in path:
+            raise LoopError(f"worker touched protected path: {path}")
+        if not paths_conflict(path, owner):
+            raise LoopError(f"worker changed unowned path: {path} outside {owner}")
+
+
+def worktree_fanin(task_dir: Path, project_root: Path, verify_command: str) -> int:
+    ledger_path = artifact_paths(task_dir)["ledger"]
+    entries = [entry for entry in parse_fanout_entries(read_text(ledger_path)) if entry["status"] == "created"]
+    if not entries:
+        raise LoopError("no created worktree fanout entries to fan in")
+    now = _dt.datetime.now(_dt.timezone.utc).replace(microsecond=0).isoformat()
+    merged = 0
+    failed = 0
+    lines = ["\n## Worktree Fanin"]
+    for entry in entries:
+        worker = Path(entry["worker"])
+        try:
+            paths = changed_paths(worker)
+            validate_worker_changes(entry, paths)
+            if paths:
+                patch_proc = git(worker, "diff", "--binary", "HEAD")
+                apply_proc = git(project_root, "apply", "--3way", input_text=patch_proc.stdout)
+                if patch_proc.returncode != 0 or apply_proc.returncode != 0:
+                    raise LoopError((patch_proc.stderr + apply_proc.stderr).strip() or "git apply failed")
+                merged += 1
+                status = "merged"
+            else:
+                status = "noop"
+            lines.append(f"- {now} task={entry['task']} worker={worker} status={status} paths={','.join(paths) or 'none'}")
+        except LoopError as exc:
+            failed += 1
+            lines.append(f"- {now} task={entry['task']} worker={worker} status=failed reason={str(exc).replace(' ', '_')}")
+    verify = subprocess.run(
+        shlex.split(verify_command),
+        cwd=project_root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    lines.append(f"- {now} verification_exit={verify.returncode} stdout={verify.stdout.strip()!r} stderr={verify.stderr.strip()!r}")
+    ledger_path.write_text(read_text(ledger_path) + "\n".join(lines) + "\n", encoding="utf-8")
+    if verify.returncode != 0:
+        return record(task_dir, "blocked", f"worktree-fanin verification_exit={verify.returncode} ledger.md#Worktree-Fanin", None, "fan-in verification command failed")
+    print(f"fanin: merged={merged} failed={failed} verification={verify.returncode}")
+    return 0 if failed == 0 else 1
+
+
 def replace_section(text: str, heading: str, body: str) -> str:
     lines = text.splitlines()
     out: list[str] = []
@@ -347,6 +492,16 @@ def main(argv: list[str] | None = None) -> int:
     run.add_argument("--adapter", required=True, help="adapter label, for example claude/codex/gemini/stub")
     run.add_argument("--command", dest="adapter_command", required=True, help="adapter command template; receives prompt on stdin; supports {task_dir} and {prompt}")
     run.add_argument("--verify-command", default=None, help="verification command template; supports {task_dir} and {prompt}")
+    fanout = sub.add_parser("fanout")
+    fanout.add_argument("--task-dir", required=True, type=Path)
+    fanout.add_argument("--project-root", required=True, type=Path)
+    fanout.add_argument("--worker-root", required=True, type=Path)
+    fanout.add_argument("--max-workers", type=int, default=4)
+    fanin = sub.add_parser("fanin")
+    fanin.add_argument("--task-dir", required=True, type=Path)
+    fanin.add_argument("--project-root", required=True, type=Path)
+    fanin.add_argument("--worker-root", required=True, type=Path, help="kept for command symmetry; fan-in reads exact worker paths from ledger")
+    fanin.add_argument("--verify-command", required=True, help="verification command that must pass after applying worker diffs")
     args = parser.parse_args(argv)
     try:
         task_dir = args.task_dir.expanduser().resolve()
@@ -358,6 +513,10 @@ def main(argv: list[str] | None = None) -> int:
             return record(task_dir, args.status, args.evidence, args.task, args.blocker)
         if args.command == "run-adapter":
             return run_adapter(task_dir, args.adapter, args.adapter_command, args.verify_command)
+        if args.command == "fanout":
+            return worktree_fanout(task_dir, args.project_root.expanduser().resolve(), args.worker_root.expanduser().resolve(), args.max_workers)
+        if args.command == "fanin":
+            return worktree_fanin(task_dir, args.project_root.expanduser().resolve(), args.verify_command)
     except LoopError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2

--- a/scripts/validate_forgeflow_loop.py
+++ b/scripts/validate_forgeflow_loop.py
@@ -153,6 +153,79 @@ def main() -> int:
         assert_contains((adapter_task_dir / "ledger.md").read_text(encoding="utf-8"), "## Agent Runs")
         assert_contains((adapter_task_dir / "ledger.md").read_text(encoding="utf-8"), "verification_exit=0")
 
+        fanout_repo = tmp / "fanout-repo"
+        fanout_repo.mkdir()
+        subprocess.run(["git", "init"], cwd=fanout_repo, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        subprocess.run(["git", "config", "user.email", "forgeflow@example.invalid"], cwd=fanout_repo, check=True)
+        subprocess.run(["git", "config", "user.name", "ForgeFlow Test"], cwd=fanout_repo, check=True)
+        (fanout_repo / "README.md").write_text("# Demo\n", encoding="utf-8")
+        subprocess.run(["git", "add", "README.md"], cwd=fanout_repo, check=True)
+        subprocess.run(["git", "commit", "-m", "init"], cwd=fanout_repo, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        fanout_task_dir = fanout_repo / ".forgeflow" / "tasks" / "fanout"
+        fanout_task_dir.mkdir(parents=True)
+        fanout_ledger = LEDGER.replace("- **Status**: done", "- **Status**: pending", 1).replace(
+            "- **Claim Marker**: none", "- **Claim Marker**: docs/a.md", 1
+        ).replace("- **Claim Marker**: none", "- **Claim Marker**: docs/b.md", 1)
+        (fanout_task_dir / "ledger.md").write_text(fanout_ledger, encoding="utf-8")
+        (fanout_task_dir / "checkpoint.md").write_text(CHECKPOINT, encoding="utf-8")
+        worker_root = tmp / "workers"
+        out = assert_ok(
+            run(
+                "fanout",
+                "--task-dir",
+                str(fanout_task_dir),
+                "--project-root",
+                str(fanout_repo),
+                "--worker-root",
+                str(worker_root),
+                cwd=ROOT,
+            )
+        )
+        assert_contains(out, "fanout: created=2")
+        workers = sorted(worker_root.iterdir())
+        if len(workers) != 2:
+            raise AssertionError(f"expected two workers, got {workers}")
+        (workers[0] / "docs").mkdir(exist_ok=True)
+        (workers[0] / "docs" / "a.md").write_text("A\n", encoding="utf-8")
+        (workers[1] / "docs").mkdir(exist_ok=True)
+        (workers[1] / "docs" / "b.md").write_text("B\n", encoding="utf-8")
+        out = assert_ok(
+            run(
+                "fanin",
+                "--task-dir",
+                str(fanout_task_dir),
+                "--project-root",
+                str(fanout_repo),
+                "--worker-root",
+                str(worker_root),
+                "--verify-command",
+                "python3 -c 'from pathlib import Path; assert Path(\"docs/a.md\").exists(); assert Path(\"docs/b.md\").exists(); print(\"fan-in verified\")'",
+                cwd=ROOT,
+            )
+        )
+        assert_contains(out, "fanin: merged=2 failed=0 verification=0")
+        assert_contains((fanout_repo / "docs" / "a.md").read_text(encoding="utf-8"), "A")
+        assert_contains((fanout_repo / "docs" / "b.md").read_text(encoding="utf-8"), "B")
+        assert_contains((fanout_task_dir / "ledger.md").read_text(encoding="utf-8"), "## Worktree Fanout")
+        assert_contains((fanout_task_dir / "ledger.md").read_text(encoding="utf-8"), "## Worktree Fanin")
+
+        failed_worker_repo = tmp / "failed-worker-repo"
+        shutil.copytree(fanout_repo, failed_worker_repo, ignore=shutil.ignore_patterns(".git"))
+        subprocess.run(["git", "init"], cwd=failed_worker_repo, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        subprocess.run(["git", "config", "user.email", "forgeflow@example.invalid"], cwd=failed_worker_repo, check=True)
+        subprocess.run(["git", "config", "user.name", "ForgeFlow Test"], cwd=failed_worker_repo, check=True)
+        subprocess.run(["git", "add", "."], cwd=failed_worker_repo, check=True)
+        subprocess.run(["git", "commit", "-m", "init"], cwd=failed_worker_repo, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        failed_task_dir = failed_worker_repo / ".forgeflow" / "tasks" / "failed"
+        failed_task_dir.mkdir(parents=True, exist_ok=True)
+        conflict_ledger = fanout_ledger.replace("docs/b.md", "docs/a.md")
+        (failed_task_dir / "ledger.md").write_text(conflict_ledger, encoding="utf-8")
+        (failed_task_dir / "checkpoint.md").write_text(CHECKPOINT, encoding="utf-8")
+        bad = run("fanout", "--task-dir", str(failed_task_dir), "--project-root", str(failed_worker_repo), "--worker-root", str(tmp / "bad-workers"), cwd=ROOT)
+        if bad.returncode == 0:
+            raise AssertionError("expected fanout conflict to fail")
+        assert_contains(bad.stderr, "conflicting path ownership")
+
         failed_verify_dir = tmp / ".forgeflow" / "tasks" / "failed-verify"
         shutil.copytree(task_dir, failed_verify_dir)
         (failed_verify_dir / "ledger.md").write_text(LEDGER, encoding="utf-8")


### PR DESCRIPTION
Closes #166

## Summary
- add fanout/fanin commands to local loop CLI
- use ledger Claim Marker as path ownership for conflict-safe worker selection
- merge worker diffs only when they stay inside owned paths and post-merge verification passes
- document the worktree loop commands

## Validation
- make validate-forgeflow-loop
- make validate